### PR TITLE
Bugfix/expose i2c pins

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.29.1) stable; urgency=medium
+
+  * added PU 47K Ohms for i2c on wb6-mod1, wb6-mod2, wb6-mod3
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 9 Apr 2020 14:41:12 +0300
+
 wb-hwconf-manager (1.29.0) stable; urgency=medium
 
   * add support for WBE2-I-1WIRE v4.0 - gpio driver

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20160117000000), linux-image-wb6 (>= 4.9+wb20181002143216) | linux-image-wb2 (>= 4.9+wb20180620083749), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20200409133112), linux-image-wb6 (>= 4.9+wb20200409133112) | linux-image-wb2 (>= 4.9+wb20200409133112), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays

--- a/modules/wbe2x-generic-i2c.dtso
+++ b/modules/wbe2x-generic-i2c.dtso
@@ -27,9 +27,7 @@
 				i2c-gpio,delay-us = <20>;       /* ~100 kHz */
 
 				pinctrl-names = "default";
-				pinctrl-0 = <SLOT_TXRX_GPIO_PINCTRL
-							 SLOT_DE_GPIO_PINCTRL
-							>;
+				pinctrl-0 = <SLOT_I2C_EXPOSE_PINCTRL>;
 
 				status = "okay";
 

--- a/slots/wb6-mod1.def
+++ b/slots/wb6-mod1.def
@@ -5,6 +5,7 @@
 
 #define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod1_txrx_gpio
 #define SLOT_TXRX_UART_PINCTRL &pinctrl_uart3_txrx
+#define SLOT_I2C_EXPOSE_PINCTRL &pinctrl_mod1_i2c_gpio
 
 #define SLOT_DE_GPIO_PINCTRL &pinctrl_mod1_de_gpio
 #define SLOT_DE_UART_PINCTRL &pinctrl_uart3_ctsb

--- a/slots/wb6-mod2.def
+++ b/slots/wb6-mod2.def
@@ -5,6 +5,7 @@
 
 #define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod2_txrx_gpio
 #define SLOT_TXRX_UART_PINCTRL &pinctrl_uart5_txrx
+#define SLOT_I2C_EXPOSE_PINCTRL &pinctrl_mod2_i2c_gpio
 
 #define SLOT_DE_GPIO_PINCTRL &pinctrl_mod2_de_gpio
 #define SLOT_DE_UART_PINCTRL &pinctrl_uart5_ctsb

--- a/slots/wb6-mod3.def
+++ b/slots/wb6-mod3.def
@@ -12,6 +12,7 @@
 
 #define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod3_txrx_gpio
 #define SLOT_TXRX_UART_PINCTRL &pinctrl_uart7_txrx
+#define SLOT_I2C_EXPOSE_PINCTRL &pinctrl_mod3_i2c_gpio
 
 #define SLOT_DE_GPIO_PINCTRL &pinctrl_mod3_de_gpio
 #define SLOT_DE_UART_PINCTRL &pinctrl_uart7_ctsb


### PR DESCRIPTION
Если в wb6-mod1/2/3 выбрать "Expose i2c-pins", то i2c-gpio использует pinctrl, где ножки подтянуты через 100К к земле. Устройства с собственной подтяжкой i2c работают нормально, а устройства без неё - нет.
Теперь для i2c подсовывается pinctrl с подтяжкой 47K наверх. [связанный PR в ядре](https://github.com/contactless/linux/pull/30)
проверял на wb6.3 и 6.6