### PR TITLE
Feature/add spi diy port

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+wb-hwconf-manager (1.32.0) stable; urgency=medium
+  * add SPI port on MOD3 for DIY
+
+ -- Andrey Radionpv <andrey.radionov@contactless.ru>  Mon, 10 Aug 2020 14:21:03 +0300
+
 wb-hwconf-manager (1.31.0) stable; urgency=medium
 
   * add support for WBMZ2-SUPERCAP EDLC mezzanine

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
 wb-hwconf-manager (1.32.0) stable; urgency=medium
-  * add SPI port on MOD3 for DIY
+  * add SPI port on WBE2S-capable extension module socket for DIY
 
  -- Andrey Radionpv <andrey.radionov@contactless.ru>  Mon, 10 Aug 2020 14:21:03 +0300
 

--- a/modules/wbe2s-generic-spi.dtso
+++ b/modules/wbe2s-generic-spi.dtso
@@ -10,7 +10,7 @@
  */
 
 / {
-	description = "Expose SPI (DIY): only SPI port";
+	description = "Expose SPI (DIY)";
 	compatible-slots = "wbe3";
 
 	fragment {

--- a/modules/wbe2s-generic-spi.dtso
+++ b/modules/wbe2s-generic-spi.dtso
@@ -24,7 +24,6 @@
 			spi@ {
 				compatible = "spidev";
 				spi-max-frequency = <20000000>;
-				voltage-ranges = <3200 3400>;
 				reg = <0>;
 			};
 		};

--- a/modules/wbe3-generic-spi.dtso
+++ b/modules/wbe3-generic-spi.dtso
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Contactless Devices, LLC.
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/ {
+	description = "Expose SPI (DIY): only SPI port";
+	compatible-slots = "wbe3";
+
+	fragment {
+		target = <SLOT_SPI_ALIAS>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <SLOT_SPI_SPI_PINCTRL>;
+
+			spi@ {
+				compatible = "spidev";
+				spi-max-frequency = <20000000>;
+				voltage-ranges = <3200 3400>;
+				reg = <0>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Добавил файлик для использования SPI порта в MOD3 для использования сторонними устройствами. Протестировано пользователем в https://support.wirenboard.com/t/rabota-s-spi-ustrojstvami/5522/7