### PR TITLE
Bugfix/wb67 w1 commonmodules

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-hwconf-manager (1.36.0) stable; urgency=medium
 
-  * fix problems wit DI-mode of 1Wire slots on WirenBoard6.7.x devices
+  * fix problems with DI-mode of 1Wire slots on WirenBoard6.7.x devices
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 15 Oct 2020 16:03:42 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.36.0) stable; urgency=medium
+
+  * fix problems wit DI-mode of 1Wire slots on WirenBoard6.7.x devices
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 15 Oct 2020 16:03:42 +0300
+
 wb-hwconf-manager (1.35.0) stable; urgency=medium
 
   * add support for WBC-4G and WBC-NB (NB-IOT) modules

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20200824121949), linux-image-wb6 (>= 4.9+wb20200824121949) | linux-image-wb2 (>= 4.9+wb20200824121949), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.7)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201015170918) | linux-image-wb2 (>= 4.9+20201015170918), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.7)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays

--- a/slots/wb67-w1.def
+++ b/slots/wb67-w1.def
@@ -1,0 +1,10 @@
+#define SLOT_ALIAS	w1
+
+#define SLOT_DATA	(JTAG_TMS,	1,	11)
+#define SLOT_PULLUP	(JTAG_TDI,	1,	13)
+
+#define SLOT_1WIRE_ALIAS	&onewire_w1
+#define SLOT_PINCTRL &pinctrl_w1_gpio
+
+#include "imx6ul-pinfunc.h"
+#include "wb6-wx.h"

--- a/slots/wb67-w1.def
+++ b/slots/wb67-w1.def
@@ -1,7 +1,7 @@
 #define SLOT_ALIAS	w1
 
-#define SLOT_DATA	(JTAG_TMS,	1,	11)
-#define SLOT_PULLUP	(JTAG_TDI,	1,	13)
+#define SLOT_DATA	(LCD_RESET,	3,	4)
+#define SLOT_PULLUP	(NAND_DQS,	4,	16)
 
 #define SLOT_1WIRE_ALIAS	&onewire_w1
 #define SLOT_PINCTRL &pinctrl_w1_gpio

--- a/slots/wb67-w2.def
+++ b/slots/wb67-w2.def
@@ -1,0 +1,10 @@
+#define SLOT_ALIAS	w2
+
+#define SLOT_DATA	(LCD_RESET,	3,	4)
+#define SLOT_PULLUP	(NAND_DQS,	4,	16)
+
+#define SLOT_1WIRE_ALIAS	&onewire_w2
+#define SLOT_PINCTRL &pinctrl_w2_gpio
+
+#include "imx6ul-pinfunc.h"
+#include "wb6-wx.h"

--- a/slots/wb67-w2.def
+++ b/slots/wb67-w2.def
@@ -1,7 +1,7 @@
 #define SLOT_ALIAS	w2
 
-#define SLOT_DATA	(LCD_RESET,	3,	4)
-#define SLOT_PULLUP	(NAND_DQS,	4,	16)
+#define SLOT_DATA	(JTAG_TMS,	1,	11)
+#define SLOT_PULLUP	(JTAG_TDI,	1,	13)
 
 #define SLOT_1WIRE_ALIAS	&onewire_w2
 #define SLOT_PINCTRL &pinctrl_w2_gpio

--- a/wb-hardware.conf.wb67
+++ b/wb-hardware.conf.wb67
@@ -112,17 +112,17 @@
             "options": {}
         },
         {
-            "id": "wb6-w1",
-            "compatible": ["wb6-wx"],
+            "id": "wb67-w1",
+            "compatible": ["wb67-wx"],
             "name": "W1 terminal mode",
-            "module": "wb6-wx-1wire",
+            "module": "wb67-wx-1wire",
             "options": {}
         },
         {
-            "id": "wb6-w2",
-            "compatible": ["wb6-wx"],
+            "id": "wb67-w2",
+            "compatible": ["wb67-wx"],
             "name": "W2 terminal mode",
-            "module": "wb6-wx-1wire",
+            "module": "wb67-wx-1wire",
             "options": {}
         }
     ]

--- a/wb-hardware.conf.wb67
+++ b/wb-hardware.conf.wb67
@@ -113,16 +113,16 @@
         },
         {
             "id": "wb67-w1",
-            "compatible": ["wb67-wx"],
+            "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
-            "module": "wb67-wx-1wire",
+            "module": "wb6-wx-1wire",
             "options": {}
         },
         {
             "id": "wb67-w2",
-            "compatible": ["wb67-wx"],
+            "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
-            "module": "wb67-wx-1wire",
+            "module": "wb6-wx-1wire",
             "options": {}
         }
     ]


### PR DESCRIPTION
По проблеме перепутанных 1Wire в wb67
Новый тип слота; в него вставляются старые модули 1wire

Альтернатива [этому](https://github.com/wirenboard/wb-hwconf-manager/pull/35/files)