### PR TITLE
Feature/dts renaming

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.37.1) stable; urgency=medium
+
+  * renaming of wb67's mod3 and mod4 in dts
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 13 Nov 2020 15:49:11 +0300
+
 wb-hwconf-manager (1.37.0) stable; urgency=medium
 
   * add support for wb67-wbmz3 slot (battery & supercap) in WirenBoard 6.7.x

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201021233713) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201116101051) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201116101051) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201117100635) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays

--- a/slots/wb67-mod3.def
+++ b/slots/wb67-mod3.def
@@ -3,10 +3,10 @@
 #define SLOT_RX		(CSI_PIXCLK,    4,	18)
 #define SLOT_RTS	(CSI_VSYNC, 4,	19)
 
-#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod4_txrx_gpio
+#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod3_txrx_gpio
 #define SLOT_TXRX_UART_PINCTRL &pinctrl_uart6_txrx
 
-#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod4_de_gpio
+#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod3_de_gpio
 #define SLOT_DE_UART_PINCTRL &pinctrl_uart6_ctsb
 
 #define SLOT_UART_ALIAS  &uart6

--- a/slots/wb67-mod3.def
+++ b/slots/wb67-mod3.def
@@ -3,10 +3,10 @@
 #define SLOT_RX		(CSI_PIXCLK,    4,	18)
 #define SLOT_RTS	(CSI_VSYNC, 4,	19)
 
-#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod3_txrx_gpio
+#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod3_txrx_gpio_new
 #define SLOT_TXRX_UART_PINCTRL &pinctrl_uart6_txrx
 
-#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod3_de_gpio
+#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod3_de_gpio_new
 #define SLOT_DE_UART_PINCTRL &pinctrl_uart6_ctsb
 
 #define SLOT_UART_ALIAS  &uart6

--- a/slots/wb67-mod4.def
+++ b/slots/wb67-mod4.def
@@ -7,14 +7,14 @@
 #define SLOT_SCK	(CSI_DATA04,	4,	25)
 #define SLOT_CS		(CSI_DATA05,	4,	26)
 
-#define SLOT_SPI_GPIO_PINCTRL &pinctrl_mod4_spi_gpio
+#define SLOT_SPI_GPIO_PINCTRL &pinctrl_mod4_spi_gpio_new
 #define SLOT_SPI_SPI_PINCTRL &pinctrl_ecspi1
 
-#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod4_txrx_gpio
+#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod4_txrx_gpio_new
 #define SLOT_TXRX_UART_PINCTRL &pinctrl_uart7_txrx
-#define SLOT_I2C_EXPOSE_PINCTRL &pinctrl_mod4_i2c_gpio
+#define SLOT_I2C_EXPOSE_PINCTRL &pinctrl_mod4_i2c_gpio_new
 
-#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod4_de_gpio
+#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod4_de_gpio_new
 #define SLOT_DE_UART_PINCTRL &pinctrl_uart7_ctsb
 
 #define SLOT_UART_ALIAS	&uart7

--- a/slots/wb67-mod4.def
+++ b/slots/wb67-mod4.def
@@ -7,14 +7,14 @@
 #define SLOT_SCK	(CSI_DATA04,	4,	25)
 #define SLOT_CS		(CSI_DATA05,	4,	26)
 
-#define SLOT_SPI_GPIO_PINCTRL &pinctrl_mod3_spi_gpio
+#define SLOT_SPI_GPIO_PINCTRL &pinctrl_mod4_spi_gpio
 #define SLOT_SPI_SPI_PINCTRL &pinctrl_ecspi1
 
-#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod3_txrx_gpio
+#define SLOT_TXRX_GPIO_PINCTRL &pinctrl_mod4_txrx_gpio
 #define SLOT_TXRX_UART_PINCTRL &pinctrl_uart7_txrx
-#define SLOT_I2C_EXPOSE_PINCTRL &pinctrl_mod3_i2c_gpio
+#define SLOT_I2C_EXPOSE_PINCTRL &pinctrl_mod4_i2c_gpio
 
-#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod3_de_gpio
+#define SLOT_DE_GPIO_PINCTRL &pinctrl_mod4_de_gpio
 #define SLOT_DE_UART_PINCTRL &pinctrl_uart7_ctsb
 
 #define SLOT_UART_ALIAS	&uart7


### PR DESCRIPTION
Mod3 и Mod4 поменялись местами (теперь мод3 - это мод3 и т.д.)
Нужно свежее ядро (где всё и поменялось, собственно)

В ядре остались старые pinctrl и добавились новые (правильные) pinctrl для mod3 & mod4 (с приставкой _new)

Возможные сценарии обновлений:
-  Ядро обновили, hwconf - нет; Работают старые pinctrl (которые непонятно названы)
-  Обновили и ядро, и hwconf; Работают новые pinctrl (_new)
-  Обновили только hwconf; Сработала зависимость, обновилось и ядро => работают новые pinctrl (_new)