### PR TITLE
Bugfix/30296 wbmz i2c fixup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.38.0) stable; urgency=medium
+
+  * fixed problems with wbmz3-battery software (by lowering I2C-bus speed)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 9 Dec 2020 14:25:11 +0300
+
 wb-hwconf-manager (1.37.0) stable; urgency=medium
 
   * add support for wb67-wbmz3 slot (battery & supercap) in WirenBoard 6.7.x

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-hwconf-manager (1.38.0) stable; urgency=medium
 
   * fixed problems with wbmz3-battery software (by lowering I2C-bus speed)
 
- -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 9 Dec 2020 14:25:11 +0300
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 9 Dec 2020 17:20:11 +0300
 
 wb-hwconf-manager (1.37.0) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201209102237) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201021233713) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201021233713) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.4.1+wb20201015170918), linux-image-wb6 (>= 4.9+wb20201209102237) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays

--- a/modules/wbmz-battery.dtsi
+++ b/modules/wbmz-battery.dtsi
@@ -19,7 +19,7 @@ fragment {
 			gpios = <SLOT_GPIO(PIN2_SDA)
 						SLOT_GPIO(PIN1_SCL)
 					>;
-			i2c-gpio,delay-us = <20>;       /* ~100 kHz */
+			i2c-gpio,delay-us = <200>;       /* ~10 kHz */
 			status = "okay";
 			__address-cells = <1>;
 			__size-cells = <0>;


### PR DESCRIPTION
Проверял на wb6.7 (со подтяжкой в ядре) и 6.6 (без подтяжки)

Контроллеры работали всю ночь - ошибок чтения/неадекватных значений не было