### PR TITLE
wbex-i-knx: rebuild knxd config on module add/remove

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.45.0) stable; urgency=medium
+
+  * Trigger KNXD config rebuild when KNX module is added or removed
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 17 Nov 2021 14:13:13 +0300
+
 wb-hwconf-manager (1.44.2) stable; urgency=medium
 
   * Add meaningful gpio line names for WBIO modules.

--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,10 @@ Homepage: https://github.com/wirenboard/wb-hwconf-manager
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc, device-tree-compiler (>= 1.6.0-1), linux-image-wb6 (>= 5.10.35-wb6~~) | linux-image-wb2 (>= 4.9+wb20200925234629), mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
-Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc,
+         device-tree-compiler (>= 1.6.0-1), linux-image-wb6 (>= 5.10.35-wb6~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
+         mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
+Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1), wb-knxd-config (<< 1.0.4~~)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays
  This package provides Device tree overlays and scripts to
  configure Wiren Board modules and onboard hardware.

--- a/modules/wbex-i-knx.sh
+++ b/modules/wbex-i-knx.sh
@@ -1,15 +1,27 @@
 source "$DATADIR/modules/utils.sh"
 
+wb_knxd_config_service_exists() {
+	systemctl --all --type service --no-legend | grep wb-knxd-config >/dev/null
+}
+
 hook_module_init() {
 	ln -s /dev/ttyMOD${SLOT_NUM} /dev/ttyKNX${SLOT_NUM}
 	if [[ ! -e /dev/ttyKNX ]]; then
 		ln -s /dev/ttyMOD${SLOT_NUM} /dev/ttyKNX	
-	fi	
+	fi
+
+	if wb_knxd_config_service_exists; then
+		systemctl restart wb-knxd-config.service
+	fi
 }
 
 hook_module_deinit() {
 	rm -f /dev/ttyKNX${SLOT_NUM}
 	if [[ $(readlink /dev/ttyKNX) == "/dev/ttyMOD${SLOT_NUM}" ]]; then
 		rm -f /dev/ttyKNX	
+	fi
+
+	if wb_knxd_config_service_exists; then
+		systemctl restart wb-knxd-config.service
 	fi
 }


### PR DESCRIPTION
Так можно автоматически обновлять конфиг knxd при подключении/отключении KNX-модуля (https://github.com/wirenboard/wb-knxd-config/pull/5)