### PR TITLE
GPIO fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-hwconf-manager (1.45.2) stable; urgency=medium
+
+  * Correct sort order is set for GPIO
+  * Default output state for module's GPIO is set to low
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 14 Dec 2021 09:13:46 +0500
+
 wb-hwconf-manager (1.45.1) stable; urgency=medium
 
   * Fix circular dependency on wb-knxd-config on boot

--- a/slots/wb-extio-v1.h
+++ b/slots/wb-extio-v1.h
@@ -27,18 +27,17 @@
    The macros concatenates EXTIO_SLOT_NUM and supplied order.
    Resulting sort order for extio pins starts from 100.
 */
-#define EXTIO_INPUT(name, pin, order) \
+#define EXTIO_INPUT(name, pin, index) \
     __cat4(EXT, EXTIO_SLOT_NUM, _, name) {\
         io-gpios = <&SLOT_DT_ALIAS(WBIO_NAME) pin GPIO_ACTIVE_HIGH>;\
         input;\
-        sort-order = <__cat(EXTIO_SLOT_NUM, order)>;\
+        sort-order = <__cat(EXTIO_SLOT_NUM, index)>;\
     }
 
-#define EXTIO_OUTPUT_HIGH(name, pin, order) \
+#define EXTIO_OUTPUT_HIGH(name, pin, index) \
     __cat4(EXT, EXTIO_SLOT_NUM, _, name) {\
         io-gpios = <&SLOT_DT_ALIAS(WBIO_NAME) pin GPIO_ACTIVE_HIGH>;\
-        output-high;\
-        sort-order = <__cat(EXTIO_SLOT_NUM, order)>;\
+        sort-order = <__cat(EXTIO_SLOT_NUM, index)>;\
     }
 
 #define EXTIO_LINE_NAME(name) \

--- a/slots/wb-wbe-gpio.h
+++ b/slots/wb-wbe-gpio.h
@@ -1,13 +1,12 @@
-#define WBE_INPUT(name, pin, order) \
+#define WBE_INPUT(name, pin, index) \
     __cat4(MOD, MOD_SLOT_NUM, _, name) {\
         io-gpios = <SLOT_GPIO(pin)>;\
         input;\
-        sort-order = <__cat(MOD_SLOT_NUM, order)>;\
+        sort-order = <__cat(MOD_SLOT_NUM, index)>;\
     }
 
-#define WBE_OUTPUT_HIGH(name, pin, order) \
+#define WBE_OUTPUT_HIGH(name, pin, index) \
     __cat4(MOD, MOD_SLOT_NUM, _, name) {\
         io-gpios = <SLOT_GPIO(pin)>;\
-        output-high;\
-        sort-order = <__cat(MOD_SLOT_NUM, order)>;\
+        sort-order = <__cat(MOD_SLOT_NUM, index)>;\
     }


### PR DESCRIPTION
  * Correct sort order is set for GPIO
  * Default output state for module's GPIO is set to low