### PR TITLE
dts_compile: dtc warnings redirected to syslog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.46.2) stable; urgency=medium
+
+  * dts_compile: dtc warnings redirected to syslog
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 03 Jan 2022 23:12:15 +0300
+
 wb-hwconf-manager (1.46.1) stable; urgency=medium
 
   * add dependency on linux-image-wb7
@@ -32,7 +38,7 @@ wb-hwconf-manager (1.45.0) stable; urgency=medium
 wb-hwconf-manager (1.44.2) stable; urgency=medium
 
   * Add meaningful gpio line names for WBIO modules.
-  They are shown in gpioinfo output and in 
+  They are shown in gpioinfo output and in
   /sys/kernel/debug/gpio
 
  -- Evgeny Boger <boger@contactless.ru>  Thu, 11 Nov 2021 04:15:30 +0300

--- a/functions.sh
+++ b/functions.sh
@@ -57,9 +57,9 @@ log() {
 catch_output() {
 	if [[ -n "$SYSLOG" ]]; then
 		2>&1 "$@" | logger -p user.info -t "$SYSLOG_TAG"
-	else 
+	else
 		"$@"
-	fi	
+	fi
 }
 
 # Join array to string
@@ -76,7 +76,7 @@ join() {
 ################################################################################
 # JSON handling functions
 #
-# It's expected that $JSON variable will contain the name of json file 
+# It's expected that $JSON variable will contain the name of json file
 # that is to be processed
 ################################################################################
 
@@ -168,7 +168,7 @@ config_slot_add() {
 		die "Slot $SLOT already present in config"
 		return 100
 	}
-	
+
 	log "Adding slot $SLOT"
 	json_array_append ".slots" \
 		"{id: \"$1\", type: \"$2\", name: \"$3\", module: \"\"}"
@@ -185,7 +185,7 @@ config_slot_del() {
 		die "Slot $SLOT not present in config"
 		return 100
 	}
-	
+
 	local m=$(config_slot_module "$SLOT")
 	[[ -n "$m" ]] && {
 		die "Slot $SLOT is used by module $m, remove it first"
@@ -276,8 +276,19 @@ slot_preprocess() {
 }
 
 # Feeds input through dtc compiler to produce dtb
+# dtc warnings => syslog; errors => syslog + stderr
 dts_compile() {
-	cat - | dtc -I dts -O dtb -@ -
+	local dtb=`mktemp`
+	dtc_output_msg=$(cat - | dtc -I dts -O dtb -@ -o $dtb 2>&1)
+	local rc=$?
+
+	SYSLOG="yes"
+	catch_output echo "$dtc_output_msg"
+	[[ $rc -ne 0 ]] && echo "$dtc_output_msg" >&2
+
+	cat $dtb
+	rm $dtb
+	return $rc
 }
 
 # Adds valid dts header to stdin
@@ -562,5 +573,3 @@ module_deinit() {
 	debug "Unloading DTBO"
 	rmdir "$t"
 }
-
-


### PR DESCRIPTION
[задача](https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/41554/) от Петра
говорит, выхлоп из journalctl. Воспроизвести не могу (с hwconf нужной версии). Мб починилось само (вокруг логов же что-то делали, кажется)?

Пока ковырялся - увидел, что всё то же самое летит в stdout при операциях с wb-hwconf-helper. Это - выхлоп dtc при dts => dtb.
Вижу 3 решения:

- "починить" все dts
- полностью спрятать ворнинги dtc (флагами или -q). Но зачем-то же они нужны
- спрятать ворнинги в syslog - сделал