### PR TITLE
add missing MOD_SLOT_NUM for older wb6x slots

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.46.2) stable; urgency=medium
+
+  * fix module slots definitions for WB6x (<< WB67)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 09 Feb 2022 19:26:26 +0300
+
 wb-hwconf-manager (1.46.1) stable; urgency=medium
 
   * add dependency on linux-image-wb7

--- a/slots/wb6-mod1.def
+++ b/slots/wb6-mod1.def
@@ -1,4 +1,5 @@
 #define SLOT_ALIAS	mod1
+#define MOD_SLOT_NUM 1
 #define SLOT_TX		(UART3_TX_DATA,	1,	24)
 #define SLOT_RX		(UART3_RX_DATA,	1,	25)
 #define SLOT_RTS	(UART3_CTS_B,	1,	26)

--- a/slots/wb6-mod2.def
+++ b/slots/wb6-mod2.def
@@ -1,4 +1,5 @@
 #define SLOT_ALIAS	mod2
+#define MOD_SLOT_NUM 2
 #define SLOT_TX		(CSI_DATA00,	4,	21)
 #define SLOT_RX		(CSI_DATA01,	4,	22)
 #define SLOT_RTS	(GPIO1_IO09,	1,	9)

--- a/slots/wb6-mod3.def
+++ b/slots/wb6-mod3.def
@@ -1,4 +1,5 @@
 #define SLOT_ALIAS	mod3
+#define MOD_SLOT_NUM 3
 #define SLOT_TX		(LCD_DATA16,	3,	21)
 #define SLOT_RX		(LCD_DATA17,	3,	22)
 #define SLOT_RTS	(LCD_DATA06,	3,	11)


### PR DESCRIPTION
Все остальные слоты проверил, больше ничего подобного не нашёл