### PR TITLE
wb7: fix interrupt on wbio modules

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.46.3) stable; urgency=medium
+
+  * wb7: fix interrupt on wbio modules
+
+ -- Evgeny Boger <boger@wirenboard.com>  Thu, 17 Feb 2022 23:40:09 +0300
+
 wb-hwconf-manager (1.46.2) stable; urgency=medium
 
   * fix module slots definitions for WB6x (<< WB67)

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: wb-hwconf-manager
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc,
          device-tree-compiler (>= 1.6.0-1),
-         linux-image-wb7 | linux-image-wb6 (>= 5.10.35-wb6~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
+         linux-image-wb7 (>= 5.10.35-wb106~~) | linux-image-wb6 (>= 5.10.35-wb6~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
          mqtt-tools (>= 1.1.1), wb-mqtt-dac (>= 1.1), wb-rules-system (>= 1.6.8)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1), wb-knxd-config (<< 1.0.4~~)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays

--- a/modules/wbio.dtsi
+++ b/modules/wbio.dtsi
@@ -18,7 +18,7 @@ fragment {
 			microchip,irq-open-drain;
 
 			interrupt-parent = <SLOT_GPIO_PORT_ALIAS(INT)>;
-			interrupts = <SLOT_GPIO_PIN(INT) IRQ_TYPE_NONE>;
+			interrupts = <SLOT_GPIO_SPEC(INT) IRQ_TYPE_NONE>;
 			interrupt-controller;
 			__interrupt-cells=<2>;
 

--- a/modules/wbio16.dtsi
+++ b/modules/wbio16.dtsi
@@ -19,7 +19,7 @@ fragment {
 			microchip,irq-mirror;
 
 			interrupt-parent = <SLOT_GPIO_PORT_ALIAS(INT)>;
-			interrupts = <SLOT_GPIO_PIN(INT) IRQ_TYPE_NONE>;
+			interrupts = <SLOT_GPIO_SPEC(INT) IRQ_TYPE_NONE>;
 			interrupt-controller;
 			__interrupt-cells=<2>;
 

--- a/slots/wb72-extio.h
+++ b/slots/wb72-extio.h
@@ -1,4 +1,4 @@
-#define SLOT_INT		(8, 18)
+#define SLOT_INT		(8, 16)
 
 #define SLOT_I2C_ALIAS	&i2c1
 


### PR DESCRIPTION
it's PI16 SoC pin, not PI18 as was set before.
Also GPIO spec macro was not valid for allwinner gpio controller.

This fix depends on fixed kernel to claim interrupt on uninitialized
GPIO.