### PR TITLE
Bugfix/overlays overlapping

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-hwconf-manager (1.52.0) stable; urgency=medium
+
+  * wb6, wb7: added ability to deinit WBIO modules in any order
+  (no labels in overlays anymore)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Sun, 05 Jun 2022 23:19:49 +0500
+
 wb-hwconf-manager (1.51.0) stable; urgency=medium
 
   * /etc/wb-mqtt-dac.conf is removed.

--- a/modules/wbio-ai-dv-12.dtso
+++ b/modules/wbio-ai-dv-12.dtso
@@ -20,20 +20,20 @@
             __address-cells = <1>;
             __size-cells = <0>;
 
-            SLOT_DT_ALIAS(aidv12_1): SLOT_DT_ALIAS(aidv12_1)@48 {
+            SLOT_DT_ALIAS(aidv12_1)@48 {
                 compatible = "ti,ads1015";
                 reg = <0x48>;
                 __address-cells = <1>;
                 __size-cells = <0>;
             };
 
-            SLOT_DT_ALIAS(aidv12_2): SLOT_DT_ALIAS(aidv12_2)@49 {
+            SLOT_DT_ALIAS(aidv12_2)@49 {
                 compatible = "ti,ads1015";
                 reg = <0x49>;
                 __address-cells = <1>;
                 __size-cells = <0>;
             };
-            SLOT_DT_ALIAS(aidv12_3): SLOT_DT_ALIAS(aidv12_3)@4a {
+            SLOT_DT_ALIAS(aidv12_3)@4a {
                 compatible = "ti,ads1015";
                 reg = <0x4a>;
                 __address-cells = <1>;

--- a/modules/wbio.dtsi
+++ b/modules/wbio.dtsi
@@ -12,7 +12,7 @@ EXTIO_FRAGMENT_NAME {
 		__address-cells = <1>;
 		__size-cells = <0>;
 
-		SLOT_DT_ALIAS(WBIO_NAME): SLOT_DT_ALIAS(WBIO_NAME)@SLOT_I2C_ADDRESS {
+		SLOT_DT_ALIAS(WBIO_NAME)@SLOT_I2C_ADDRESS {
 			compatible = "microchip,mcp23008";
 			gpio-controller;
 			__gpio-cells = <2>;

--- a/modules/wbio.dtsi
+++ b/modules/wbio.dtsi
@@ -5,7 +5,7 @@
 #ifdef WBIO_OUTPUT
 #define SLOT_I2C_ADDRESS SLOT_I2C_ADDRESS_OUT
 #endif
-fragment {
+EXTIO_FRAGMENT_NAME {
 	target = <SLOT_I2C_ALIAS>;
 
 	__overlay__ {

--- a/modules/wbio16.dtsi
+++ b/modules/wbio16.dtsi
@@ -12,7 +12,7 @@ EXTIO_FRAGMENT_NAME {
 		__address-cells = <1>;
 		__size-cells = <0>;
 
-		SLOT_DT_ALIAS(WBIO_NAME): SLOT_DT_ALIAS(WBIO_NAME)@SLOT_I2C_ADDRESS {
+		SLOT_DT_ALIAS(WBIO_NAME)@SLOT_I2C_ADDRESS {
 			compatible = "microchip,mcp23017";
 			gpio-controller;
 			__gpio-cells = <2>;

--- a/modules/wbio16.dtsi
+++ b/modules/wbio16.dtsi
@@ -5,7 +5,7 @@
 #ifdef WBIO_OUTPUT
 #define SLOT_I2C_ADDRESS SLOT_I2C_ADDRESS_OUT
 #endif
-fragment {
+EXTIO_FRAGMENT_NAME {
 	target = <SLOT_I2C_ALIAS>;
 
 	__overlay__ {

--- a/slots/wb-extio-common.h
+++ b/slots/wb-extio-common.h
@@ -12,6 +12,8 @@
 #define SLOT_GPIO_BASE_8		__pass(__arg4 SLOT_DEF)
 #define SLOT_GPIO_BASE_40		__pass(__arg5 SLOT_DEF)
 
+#define EXTIO_FRAGMENT_NAME fragment_i2c_extio
+
 /* order for EXTIO_INPUT and EXTIO_OUTPUT_HIGH
    must be two digit number, 1 must be 01, 2 - 02 etc.
    The macros concatenates EXTIO_SLOT_NUM and supplied order.

--- a/slots/wb-extio-common.h
+++ b/slots/wb-extio-common.h
@@ -21,14 +21,14 @@
 */
 #define EXTIO_INPUT(name, pin, index) \
     __cat4(EXT, EXTIO_SLOT_NUM, _, name) {\
-        io-gpios = <&SLOT_DT_ALIAS(WBIO_NAME) pin GPIO_ACTIVE_HIGH>;\
+        io-gpios = <&{/EXTIO_FRAGMENT_NAME/__overlay__/SLOT_DT_ALIAS(WBIO_NAME)@SLOT_I2C_ADDRESS} pin GPIO_ACTIVE_HIGH>;\
         input;\
         sort-order = <__cat(EXTIO_SLOT_NUM, index)>;\
     }
 
 #define EXTIO_OUTPUT_HIGH(name, pin, index) \
     __cat4(EXT, EXTIO_SLOT_NUM, _, name) {\
-        io-gpios = <&SLOT_DT_ALIAS(WBIO_NAME) pin GPIO_ACTIVE_HIGH>;\
+        io-gpios = <&{/EXTIO_FRAGMENT_NAME/__overlay__/SLOT_DT_ALIAS(WBIO_NAME)@SLOT_I2C_ADDRESS} pin GPIO_ACTIVE_HIGH>;\
         sort-order = <__cat(EXTIO_SLOT_NUM, index)>;\
     }
 


### PR DESCRIPTION
"проблема WD14 - R10R4"

контекст - на скрине
![2022-06-06_11-24-20](https://user-images.githubusercontent.com/25829054/172130333-f9b46bfe-1e63-4128-9291-49fe57d9a02b.png)


технически - ноги росли из "застревания" модулей в dts из-за конфиликта `__symbols__`
решение подсказал @nikitoz236 (оказывается, проблема - известная, и что-то написано на intwiki). 
не используем labels; phandle берем из полного пути (доступен в пределах одного dtb, что оказалось довольно неочевидным)

погонял с gpio-расширителями и ai-dv-12. Теперь порядок вытаскивания wbio из dts неважен