### PR TITLE
WBIO-AI-DV-12 dts is modified to use ADS1115 instead of ADS1015

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.52.1) stable; urgency=medium
+
+  * WBIO-AI-DV-12 dts is modified to use ADS1115 instead of ADS1015
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 14 Jun 2022 11:13:36 +0500
+
 wb-hwconf-manager (1.52.0) stable; urgency=medium
 
   * wb6, wb7: added ability to deinit WBIO modules in any order

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-config
          linux-image-wb7 (>= 5.10.35-wb109~~) | linux-image-wb6 (>= 5.10.35-wb109~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
          mqtt-tools (>= 1.1.1), wb-rules-system (>= 1.6.8),
          ntpstat
-Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 1.14.2), wb-mqtt-homeui (<< 1.6.1), wb-knxd-config (<< 1.0.4~~), wb-mqtt-dac (<< 1.2.0)
+Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 2.5.0), wb-mqtt-homeui (<< 1.6.1), wb-knxd-config (<< 1.0.4~~), wb-mqtt-dac (<< 1.2.0)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays
  This package provides Device tree overlays and scripts to
  configure Wiren Board modules and onboard hardware.

--- a/modules/wbio-ai-dv-12.dtso
+++ b/modules/wbio-ai-dv-12.dtso
@@ -21,20 +21,20 @@
             __size-cells = <0>;
 
             SLOT_DT_ALIAS(aidv12_1)@48 {
-                compatible = "ti,ads1015";
+                compatible = "ti,ads1115";
                 reg = <0x48>;
                 __address-cells = <1>;
                 __size-cells = <0>;
             };
 
             SLOT_DT_ALIAS(aidv12_2)@49 {
-                compatible = "ti,ads1015";
+                compatible = "ti,ads1115";
                 reg = <0x49>;
                 __address-cells = <1>;
                 __size-cells = <0>;
             };
             SLOT_DT_ALIAS(aidv12_3)@4a {
-                compatible = "ti,ads1015";
+                compatible = "ti,ads1115";
                 reg = <0x4a>;
                 __address-cells = <1>;
                 __size-cells = <0>;

--- a/modules/wbio-ai-dv-12.sh
+++ b/modules/wbio-ai-dv-12.sh
@@ -37,12 +37,12 @@ hook_module_add() {
 			local scale mqtt_type
 			case ${chan_mode} in
 				"voltage")
-					scale=2
+					scale=0.125
 					voltage_multiplier=1
 					mqtt_type="voltage"
 					;;
 				"current_20ma")
-					scale=1
+					scale=0.0625
 					voltage_multiplier=0.01
 					mqtt_type="current"
 					;;
@@ -86,11 +86,11 @@ hook_module_add() {
 				case "$chan0_mode" in
 					"voltage")
 						voltage_multiplier=1
-						scale=0.5
+						scale=0.03125
 						;;
 					"voltage_pm50")
 						voltage_multiplier=21.26
-						scale=2
+						scale=0.125
 						;;
 					*)
 						continue;


### PR DESCRIPTION
Some WBIO-AI-DV-12 have ADS1115, some - ADS1015. It's impossible to define the chip used. So ADS1115 is set in dts as it has longest conversion time.