### PR TITLE
fix module deleting when corresponding service is inactive

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.52.7) stable; urgency=medium
+
+  * Fix WBIO-AI-DV-12 deleting when wb-mqtt-adc service is inactive
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 25 Aug 2022 15:08:16 +0300
+
 wb-hwconf-manager (1.52.6) stable; urgency=medium
 
   * Workaround for ERRWB730001: hide CAN and CAN-UART on broken WB rev 7.3,

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -69,7 +69,7 @@ slot_i2c_dev_sysfs() {
 # Args:
 # - service name (from /etc/init.d/)
 service_restart() {
-	[[ -z "$NO_RESTART_SERVICE" ]] && service "$1" restart
+	if [[ -z "$NO_RESTART_SERVICE" ]]; then service "$1" restart; fi
 }
 
 # Restarts given service if $NO_RESTART_SERVICE is not set,
@@ -78,11 +78,11 @@ service_restart() {
 # - service name (from /etc/init.d/)
 # - MQTT topic to delete
 service_restart_delete_retained() {
-	[[ -z "$NO_RESTART_SERVICE" ]] && {
+	if [[ -z "$NO_RESTART_SERVICE" ]]; then
 		service "$1" stop
 		mqtt-delete-retained "$2"
 		service "$1" start
-	}
+	fi
 }
 
 SYSFS_GPIO="/sys/class/gpio"
@@ -128,11 +128,11 @@ sysfs_gpio_set() {
 # - service name
 # - MQTT topic to delete
 stop_service_and_schedule_restart() {
-	[[ -z "$NO_RESTART_SERVICE" ]] && {
+	if [[ -z "$NO_RESTART_SERVICE" ]]; then
 		local act=`systemctl is-active "$1"`
-		[[ "$act" == "active" ]] &&	{
+		if [[ "$act" == "active" ]]; then
 			systemctl stop "$1"
 			hook_once_after_config_change "service_restart_delete_retained $1 $2"
-		}
-	}
+		fi
+	fi
 }


### PR DESCRIPTION
This shot on wbio-ai-dv-12 when wb-mqtt-adc service is inactive.

Problem is in `[[ x ]] && { y }` statement: when `[[ x ]]` is false, bash returns false for the whole sentence.

Because of this and `while` in the wb-hwconf-helper, delete procedure entered an infinite loop.

`if [[ x ]]; then y; fi` statement is better because does not return bad exit codes, so, no loops here.