### PR TITLE
Start/stop wb-gsm service after WBC-4G v.2 configuration

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.53.0) stable; urgency=medium
+
+  * Start/stop wb-gsm service after WBC-4G v.2 configuration
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 19 Sep 2022 16:00:42 +0500
+
 wb-hwconf-manager (1.52.7) stable; urgency=medium
 
   * Fix WBIO-AI-DV-12 deleting when wb-mqtt-adc service is inactive

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/wirenboard/wb-hwconf-manager
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 2.1.2), wb-configs (>= 1.63), perl, jq, tcc,
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.1.0), wb-configs (>= 1.63), perl, jq, tcc,
          device-tree-compiler (>= 1.6.0-1),
          linux-image-wb7 (>= 5.10.35-wb109~~) | linux-image-wb6 (>= 5.10.35-wb109~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
          mqtt-tools (>= 1.1.1), wb-rules-system (>= 1.6.8),

--- a/modules/wbc-4g-usb.sh
+++ b/modules/wbc-4g-usb.sh
@@ -1,0 +1,11 @@
+source "$DATADIR/modules/utils.sh"
+
+hook_module_add() {
+	hook_once_after_config_change "service_restart wb-gsm"
+}
+
+hook_module_del() {
+	[[ -z "$NO_RESTART_SERVICE" ]] && {
+		systemctl stop wb-gsm || true
+	}
+}


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/wb-hwconf-manager/pull/90