### PR TITLE
Feature/52216 lora support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-hwconf-manager (1.54.0) stable; urgency=medium
+
+  * add wbe2r-r-lora module
+  * fix gpionums acquiring from slots defs
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 05 Oct 2022 22:51:39 +0500
+
 wb-hwconf-manager (1.53.0) stable; urgency=medium
 
   * Start/stop wb-gsm service after WBC-4G v.2 configuration

--- a/modules/wbe2r-r-lora.dtso
+++ b/modules/wbe2r-r-lora.dtso
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Contactless Devices, LLC.
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/ {
+	description = "WBE2R-R-LORA: LoRa Interface";
+	compatible-slots = "wbe3-reduced";
+
+fragment@0 {
+	target = <SLOT_UART_ALIAS>;
+
+	__overlay__ {
+		status = "okay";
+		pinctrl-names = "default";
+		pinctrl-0 = <SLOT_TXRX_UART_PINCTRL SLOT_DE_GPIO_PINCTRL>;
+	};
+};
+
+};

--- a/modules/wbe2r-r-lora.sh
+++ b/modules/wbe2r-r-lora.sh
@@ -1,14 +1,34 @@
 source "$DATADIR/modules/utils.sh"
 
+local CONFIG_SERIAL=${CONFIG_SERIAL:-/etc/wb-mqtt-serial.conf}
+
 hook_module_init() {
 	sysfs_gpio_export $GPIO_RTS
 	sysfs_gpio_direction $GPIO_RTS out
 
 	sysfs_gpio_set $GPIO_RTS 0
-	echo "set gpio$GPIO_RTS -> 0"
 }
 
 hook_module_deinit() {
 	sysfs_gpio_direction $GPIO_RTS in
 	sysfs_gpio_unexport $GPIO_RTS
+}
+
+hook_module_add() {
+	local JSON=$CONFIG_SERIAL
+	json_array_update ".ports" ".path == \"/dev/ttyMOD${SLOT_NUM}\"" ".enabled = true |
+		.stop_bits = 1 |
+		.baud_rate = 9600 |
+		.parity = \"N\" |
+		.data_bits = 8"
+}
+
+hook_module_del() {
+	local JSON=$CONFIG_SERIAL
+	json_array_update ".ports" ".path == \"/dev/ttyMOD${SLOT_NUM}\"" ".enabled = false |
+		.stop_bits = 2 |
+		.baud_rate = 9600 |
+		.parity = \"N\" |
+		.data_bits = 8 |
+		.devices = []"
 }

--- a/modules/wbe2r-r-lora.sh
+++ b/modules/wbe2r-r-lora.sh
@@ -1,0 +1,14 @@
+source "$DATADIR/modules/utils.sh"
+
+hook_module_init() {
+	sysfs_gpio_export $GPIO_RTS
+	sysfs_gpio_direction $GPIO_RTS out
+
+	sysfs_gpio_set $GPIO_RTS 0
+	echo "set gpio$GPIO_RTS -> 0"
+}
+
+hook_module_deinit() {
+	sysfs_gpio_direction $GPIO_RTS in
+	sysfs_gpio_unexport $GPIO_RTS
+}

--- a/modules/wbe2r-r-lora.sh
+++ b/modules/wbe2r-r-lora.sh
@@ -6,7 +6,7 @@ hook_module_init() {
 	sysfs_gpio_export $GPIO_RTS
 	sysfs_gpio_direction $GPIO_RTS out
 
-	sysfs_gpio_set $GPIO_RTS 0
+	sysfs_gpio_set $GPIO_RTS 0  # setting lora module to working mode
 }
 
 hook_module_deinit() {
@@ -14,16 +14,17 @@ hook_module_deinit() {
 	sysfs_gpio_unexport $GPIO_RTS
 }
 
-hook_module_add() {
+hook_module_add() {  # lora chip supports only 9600-8-N-1 settings
 	local JSON=$CONFIG_SERIAL
 	json_array_update ".ports" ".path == \"/dev/ttyMOD${SLOT_NUM}\"" ".enabled = true |
 		.stop_bits = 1 |
 		.baud_rate = 9600 |
 		.parity = \"N\" |
-		.data_bits = 8"
+		.data_bits = 8 |
+		.response_timeout_ms = 8000"  # to prevent red-coloring of devices in webui
 }
 
-hook_module_del() {
+hook_module_del() {  # restoring default settings (9600-8-N-2; disabled; default response_timeout_ms)
 	local JSON=$CONFIG_SERIAL
 	json_array_update ".ports" ".path == \"/dev/ttyMOD${SLOT_NUM}\"" ".enabled = false |
 		.stop_bits = 2 |
@@ -31,4 +32,7 @@ hook_module_del() {
 		.parity = \"N\" |
 		.data_bits = 8 |
 		.devices = []"
+	json_edit "del(.ports[] | select(.path == \"/dev/ttyMOD${SLOT_NUM}\") | .response_timeout_ms)"
+
+    hook_once_after_config_change "service_restart wb-mqtt-serial"
 }

--- a/slots/wb6-mod1.def
+++ b/slots/wb6-mod1.def
@@ -13,4 +13,4 @@
 #define SLOT_UART_ALIAS  &uart3
 
 #include "wbe2.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb6-mod1.def
+++ b/slots/wb6-mod1.def
@@ -12,5 +12,5 @@
 
 #define SLOT_UART_ALIAS  &uart3
 
-#include "imx6ul-soc.h"
 #include "wbe2.h"
+#include "imx6ul-soc.h"

--- a/slots/wb6-mod2.def
+++ b/slots/wb6-mod2.def
@@ -14,5 +14,5 @@
 
 #define SLOT_NEED_CONTROL_JTAG_MOD
 
-#include "imx6ul-soc.h"
 #include "wbe2.h"
+#include "imx6ul-soc.h"

--- a/slots/wb6-mod2.def
+++ b/slots/wb6-mod2.def
@@ -15,4 +15,4 @@
 #define SLOT_NEED_CONTROL_JTAG_MOD
 
 #include "wbe2.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb6-mod3.def
+++ b/slots/wb6-mod3.def
@@ -20,5 +20,5 @@
 #define SLOT_UART_ALIAS	&uart7
 #define SLOT_SPI_ALIAS	&ecspi1
 
-#include "imx6ul-soc.h"
 #include "wbe3.h"
+#include "imx6ul-soc.h"

--- a/slots/wb6-mod3.def
+++ b/slots/wb6-mod3.def
@@ -21,4 +21,4 @@
 #define SLOT_SPI_ALIAS	&ecspi1
 
 #include "wbe3.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb6-w1.def
+++ b/slots/wb6-w1.def
@@ -8,4 +8,4 @@
 #define SLOT_PINCTRL &pinctrl_w1_gpio
 
 #include "wb6-wx.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb6-w1.def
+++ b/slots/wb6-w1.def
@@ -7,5 +7,5 @@
 #define SLOT_1WIRE_ALIAS	&onewire_w1
 #define SLOT_PINCTRL &pinctrl_w1_gpio
 
-#include "imx6ul-soc.h"
 #include "wb6-wx.h"
+#include "imx6ul-soc.h"

--- a/slots/wb6-w2.def
+++ b/slots/wb6-w2.def
@@ -7,5 +7,5 @@
 #define SLOT_1WIRE_ALIAS	&onewire_w2
 #define SLOT_PINCTRL &pinctrl_w2_gpio
 
-#include "imx6ul-soc.h"
 #include "wb6-wx.h"
+#include "imx6ul-soc.h"

--- a/slots/wb6-w2.def
+++ b/slots/wb6-w2.def
@@ -8,4 +8,4 @@
 #define SLOT_PINCTRL &pinctrl_w2_gpio
 
 #include "wb6-wx.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb6-wbmz.h
+++ b/slots/wb6-wbmz.h
@@ -2,12 +2,11 @@
 #define SLOT_PIN1_SCL		(UART1_CTS_B,	1,	18)
 #define SLOT_PIN2_SDA		(UART1_RTS_B,	1,	19)
 
-
-#include "imx6ul-soc.h"
-
 /* All known pins for module */
 #define SLOT_ALL_PINS \
 	SLOT_FOR_PIN(PIN1_SCL) \
 	SLOT_FOR_PIN(PIN2_SDA)
+
+#include "imx6ul-soc.h"
 
 #include "utils.h"

--- a/slots/wb6-wbmz.h
+++ b/slots/wb6-wbmz.h
@@ -7,6 +7,6 @@
 	SLOT_FOR_PIN(PIN1_SCL) \
 	SLOT_FOR_PIN(PIN2_SDA)
 
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined
 
 #include "utils.h"

--- a/slots/wb67-mod1.def
+++ b/slots/wb67-mod1.def
@@ -13,4 +13,4 @@
 #define SLOT_UART_ALIAS  &uart3
 
 #include "wbe2.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb67-mod1.def
+++ b/slots/wb67-mod1.def
@@ -12,5 +12,5 @@
 
 #define SLOT_UART_ALIAS  &uart3
 
-#include "imx6ul-soc.h"
 #include "wbe2.h"
+#include "imx6ul-soc.h"

--- a/slots/wb67-mod2.def
+++ b/slots/wb67-mod2.def
@@ -14,5 +14,5 @@
 
 #define SLOT_NEED_CONTROL_JTAG_MOD
 
-#include "imx6ul-soc.h"
 #include "wbe2.h"
+#include "imx6ul-soc.h"

--- a/slots/wb67-mod2.def
+++ b/slots/wb67-mod2.def
@@ -15,4 +15,4 @@
 #define SLOT_NEED_CONTROL_JTAG_MOD
 
 #include "wbe2.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb67-mod3.def
+++ b/slots/wb67-mod3.def
@@ -14,5 +14,5 @@
 
 #define SLOT_NEED_CONTROL_JTAG_MOD
 
-#include "imx6ul-soc.h"
 #include "wbe2.h"
+#include "imx6ul-soc.h"

--- a/slots/wb67-mod3.def
+++ b/slots/wb67-mod3.def
@@ -15,4 +15,4 @@
 #define SLOT_NEED_CONTROL_JTAG_MOD
 
 #include "wbe2.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb67-mod4.def
+++ b/slots/wb67-mod4.def
@@ -20,5 +20,5 @@
 #define SLOT_UART_ALIAS	&uart7
 #define SLOT_SPI_ALIAS	&ecspi1
 
-#include "imx6ul-soc.h"
 #include "wbe3.h"
+#include "imx6ul-soc.h"

--- a/slots/wb67-mod4.def
+++ b/slots/wb67-mod4.def
@@ -21,4 +21,4 @@
 #define SLOT_SPI_ALIAS	&ecspi1
 
 #include "wbe3.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb67-w1.def
+++ b/slots/wb67-w1.def
@@ -8,4 +8,4 @@
 #define SLOT_PINCTRL &pinctrl_w1_gpio
 
 #include "wb6-wx.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb67-w1.def
+++ b/slots/wb67-w1.def
@@ -7,5 +7,5 @@
 #define SLOT_1WIRE_ALIAS	&onewire_w1
 #define SLOT_PINCTRL &pinctrl_w1_gpio
 
-#include "imx6ul-soc.h"
 #include "wb6-wx.h"
+#include "imx6ul-soc.h"

--- a/slots/wb67-w2.def
+++ b/slots/wb67-w2.def
@@ -7,5 +7,5 @@
 #define SLOT_1WIRE_ALIAS	&onewire_w2
 #define SLOT_PINCTRL &pinctrl_w2_gpio
 
-#include "imx6ul-soc.h"
 #include "wb6-wx.h"
+#include "imx6ul-soc.h"

--- a/slots/wb67-w2.def
+++ b/slots/wb67-w2.def
@@ -8,4 +8,4 @@
 #define SLOT_PINCTRL &pinctrl_w2_gpio
 
 #include "wb6-wx.h"
-#include "imx6ul-soc.h"
+#include "imx6ul-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb72-mod1.def
+++ b/slots/wb72-mod1.def
@@ -12,5 +12,5 @@
 
 #define SLOT_UART_ALIAS  &uart7
 
-#include "r40-soc.h"
 #include "wbe2.h"
+#include "r40-soc.h"

--- a/slots/wb72-mod1.def
+++ b/slots/wb72-mod1.def
@@ -13,4 +13,4 @@
 #define SLOT_UART_ALIAS  &uart7
 
 #include "wbe2.h"
-#include "r40-soc.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb72-mod2.def
+++ b/slots/wb72-mod2.def
@@ -13,4 +13,4 @@
 #define SLOT_UART_ALIAS  &uart6
 
 #include "wbe2.h"
-#include "r40-soc.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb72-mod2.def
+++ b/slots/wb72-mod2.def
@@ -12,5 +12,5 @@
 
 #define SLOT_UART_ALIAS  &uart6
 
-#include "r40-soc.h"
 #include "wbe2.h"
+#include "r40-soc.h"

--- a/slots/wb72-mod3.def
+++ b/slots/wb72-mod3.def
@@ -12,5 +12,5 @@
 
 #define SLOT_UART_ALIAS  &uart5
 
-#include "r40-soc.h"
 #include "wbe2.h"
+#include "r40-soc.h"

--- a/slots/wb72-mod3.def
+++ b/slots/wb72-mod3.def
@@ -13,4 +13,4 @@
 #define SLOT_UART_ALIAS  &uart5
 
 #include "wbe2.h"
-#include "r40-soc.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb72-mod4.def
+++ b/slots/wb72-mod4.def
@@ -21,4 +21,4 @@
 #define SLOT_SPI_ALIAS	&spi0
 
 #include "wbe3.h"
-#include "r40-soc.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb72-mod4.def
+++ b/slots/wb72-mod4.def
@@ -20,5 +20,5 @@
 #define SLOT_UART_ALIAS	&uart3
 #define SLOT_SPI_ALIAS	&spi0
 
-#include "r40-soc.h"
 #include "wbe3.h"
+#include "r40-soc.h"

--- a/slots/wb72-w1.def
+++ b/slots/wb72-w1.def
@@ -7,5 +7,5 @@
 #define SLOT_1WIRE_ALIAS	&onewire_w1
 #define SLOT_PINCTRL &pinctrl_w1_gpio
 
-#include "r40-soc.h"
 #include "wb6-wx.h"
+#include "r40-soc.h"

--- a/slots/wb72-w1.def
+++ b/slots/wb72-w1.def
@@ -8,4 +8,4 @@
 #define SLOT_PINCTRL &pinctrl_w1_gpio
 
 #include "wb6-wx.h"
-#include "r40-soc.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb72-w2.def
+++ b/slots/wb72-w2.def
@@ -8,4 +8,4 @@
 #define SLOT_PINCTRL &pinctrl_w2_gpio
 
 #include "wb6-wx.h"
-#include "r40-soc.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb72-w2.def
+++ b/slots/wb72-w2.def
@@ -7,5 +7,5 @@
 #define SLOT_1WIRE_ALIAS	&onewire_w2
 #define SLOT_PINCTRL &pinctrl_w2_gpio
 
-#include "r40-soc.h"
 #include "wb6-wx.h"
+#include "r40-soc.h"


### PR DESCRIPTION
Поддержка lora-модуля. В хотелках к задаче:
- прижать rts в 0
- настроить порт в конфиге сериала на 9600-8-N-1

Тыкая gpio, обнаружил, что у нас поломался механизм вытаскивания номера gpio из def'ов слота. Причина - не отрабатывали наполняющие номера gpio [макросы](https://github.com/wirenboard/wb-hwconf-manager/blob/46a70210ebe68d95100d868cd96893dd2dfa841f/slots/imx-common.h#L44), т.к. ...-soc.h инклюдился раньше определения `SLOT_ALL_PINS`


пока что с wbmz-батарейкой не гонял; у меня нет; схожу в офис