### PR TITLE
wb-hwconf-manager.service: start before networking.service

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-hwconf-manager (1.52.7-wb101) stable; urgency=medium
+
+  * starting before networking.service
+  This fixes race, when networking tries to bring up ppp on not configured modem
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 14 Oct 2022 11:56:21 +0500
+
 wb-hwconf-manager (1.52.7-wb100) stable; urgency=medium
 
   * add wbe2r-r-lora module

--- a/debian/wb-hwconf-manager.service
+++ b/debian/wb-hwconf-manager.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Initialize Wiren Board Device Tree overlays
+Before=networking.service
 After=local-fs.target wb-configs.service
 
 [Service]


### PR DESCRIPTION
поправил [PR](https://github.com/wirenboard/wb-configs/pull/71) вокруг ppp
рисёчь можно почитать в том PR