### PR TITLE
wbc-4g-usb: reveal mm-gsm-connections on modem init and hide on deinit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.58.0) stable; urgency=medium
+
+  * wbc-4g-usb: reveal mm-gsm-connections on modem init and hide on deinit
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 28 Mar 2022 23:17:18 +0500
+
 wb-hwconf-manager (1.57.1) stable; urgency=medium
 
   * wbe2r-r-zwave: add translation

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.1.0), wb-config
          linux-image-wb7 (>= 5.10.35-wb109~~) | linux-image-wb6 (>= 5.10.35-wb109~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
          mqtt-tools (>= 1.1.1), wb-rules-system (>= 1.6.8),
          ntpstat
+Recommends: wb-nm-helper (>= 1.22.0~~)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 2.5.0), wb-mqtt-homeui (<< 1.6.1), wb-knxd-config (<< 1.0.4~~), wb-mqtt-dac (<< 1.2.0)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays
  This package provides Device tree overlays and scripts to

--- a/debian/control
+++ b/debian/control
@@ -13,8 +13,8 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.1.0), wb-config
          linux-image-wb7 (>= 5.10.35-wb109~~) | linux-image-wb6 (>= 5.10.35-wb109~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
          mqtt-tools (>= 1.1.1), wb-rules-system (>= 1.6.8),
          ntpstat
-Recommends: wb-nm-helper (>= 1.22.0~~)
-Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 2.5.0), wb-mqtt-homeui (<< 1.6.1), wb-knxd-config (<< 1.0.4~~), wb-mqtt-dac (<< 1.2.0)
+Breaks: wb-nm-helper (<< 1.22.0~~), wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 2.5.0), wb-mqtt-homeui (<< 1.6.1),
+         wb-knxd-config (<< 1.0.4~~), wb-mqtt-dac (<< 1.2.0)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays
  This package provides Device tree overlays and scripts to
  configure Wiren Board modules and onboard hardware.

--- a/modules/wbc-4g-usb.sh
+++ b/modules/wbc-4g-usb.sh
@@ -1,10 +1,20 @@
 source "$DATADIR/modules/utils.sh"
 
+hide_modem_connections() {
+	[[ -f "/usr/lib/wb-nm-helper/wb-hide-connection" ]] && {
+		for conn_id in wb-gsm-sim1 wb-gsm-sim2; do
+			/usr/lib/wb-nm-helper/wb-hide-connection $conn_id "$1"
+		done
+	}
+}
+
 hook_module_add() {
+	hide_modem_connections ""
 	hook_once_after_config_change "service_restart wb-gsm"
 }
 
 hook_module_del() {
+	hide_modem_connections "true"
 	[[ -z "$NO_RESTART_SERVICE" ]] && {
 		systemctl stop wb-gsm || true
 	}


### PR DESCRIPTION
Хвконф-часть скрытия модемных соединений. Если модем выставлен в hardware.conf - соединения показываются; не выставлен - нет. Также и после ребутов