### PR TITLE
Feature/53386 env cache

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.58.0) stable; urgency=medium
+
+  * wb-hwconf-helper: validate env cache after init/deinit/config-apply
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 11 May 2023 20:12:51 +0500
+
 wb-hwconf-manager (1.57.1) stable; urgency=medium
 
   * wbe2r-r-zwave: add translation

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/wirenboard/wb-hwconf-manager
 
 Package: wb-hwconf-manager
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.1.0), wb-configs (>= 1.63), perl, jq, tcc,
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 4.10.0~~), wb-configs (>= 1.63), perl, jq, tcc,
          device-tree-compiler (>= 1.6.0-1),
          linux-image-wb7 (>= 5.10.35-wb109~~) | linux-image-wb6 (>= 5.10.35-wb109~~) | linux-image-wb2 (>= 4.9+wb20200925234629),
          mqtt-tools (>= 1.1.1), wb-rules-system (>= 1.6.8),

--- a/wb-hwconf-helper
+++ b/wb-hwconf-helper
@@ -165,12 +165,15 @@ case "$1" in
 		;;
 	"init")
 		module_init $2 $3
+		source "/usr/lib/wb-utils/wb_env.sh"
 		;;
 	"deinit")
 		module_deinit $2
+		source "/usr/lib/wb-utils/wb_env.sh"
 		;;
 	"config-apply")
 		config_apply_changes
+		source "/usr/lib/wb-utils/wb_env.sh"
 		;;
 	"load-overlay")
 		if [ "$#" -ne 2 ]; then


### PR DESCRIPTION
Иногда wb при запуске сабшеллов тормозит. Вероятная причина - валидация wb_env кеша. Такое может происходить после действий с хвконфом

Связанный [PR](https://github.com/wirenboard/wb-utils/pull/99)