### PR TITLE
Feature/stuck fixup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.57.2) stable; urgency=medium
+
+  * wbc-4g-usb: fix deinit hook to prevent boot stuck
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 18 May 2023 17:12:14 +0500
+
 wb-hwconf-manager (1.57.1) stable; urgency=medium
 
   * wbe2r-r-zwave: add translation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-hwconf-manager (1.57.2) stable; urgency=medium
 
   * wbc-4g-usb: fix deinit hook to prevent boot stuck
+  * .service: add startup timeout
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 18 May 2023 17:12:14 +0500
 

--- a/debian/wb-hwconf-manager.service
+++ b/debian/wb-hwconf-manager.service
@@ -8,7 +8,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/usr/lib/wb-hwconf-manager/firstboot.sh
 ExecStart=/usr/lib/wb-hwconf-manager/init.sh
-TimeoutSec=600
+TimeoutSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/wb-hwconf-manager.service
+++ b/debian/wb-hwconf-manager.service
@@ -8,6 +8,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/usr/lib/wb-hwconf-manager/firstboot.sh
 ExecStart=/usr/lib/wb-hwconf-manager/init.sh
+TimeoutSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/wbc-4g-usb.sh
+++ b/modules/wbc-4g-usb.sh
@@ -5,8 +5,7 @@ hook_module_add() {
 }
 
 hook_module_del() {
-	[[ -z "$NO_RESTART_SERVICE" ]] && {
+	if [[ -z "$NO_RESTART_SERVICE" ]]; then
 		systemctl stop wb-gsm || true
-	}
-	:  # to prevent empty-func error
+	fi;
 }

--- a/modules/wbc-4g-usb.sh
+++ b/modules/wbc-4g-usb.sh
@@ -7,5 +7,5 @@ hook_module_add() {
 hook_module_del() {
 	[[ -z "$NO_RESTART_SERVICE" ]] && {
 		systemctl stop wb-gsm || true
-	}
+	} || true
 }

--- a/modules/wbc-4g-usb.sh
+++ b/modules/wbc-4g-usb.sh
@@ -7,5 +7,6 @@ hook_module_add() {
 hook_module_del() {
 	[[ -z "$NO_RESTART_SERVICE" ]] && {
 		systemctl stop wb-gsm || true
-	} || true
+	}
+	:  # to prevent empty-func error
 }


### PR DESCRIPTION
если выставить в webui модем => убрать его из конфига (не сделав config-apply) => перезагрузиться - получим ситуацию, когда надо сделать deinit с установленной [переменной](https://github.com/wirenboard/wb-hwconf-manager/blob/4eb1ce1dc3db26d07a7241c78cfa456a26d6bbbf/init.sh#L5)

это приводит к неверному синтаксису и зависанию wb-hwconf-manager.service [здесь](https://github.com/wirenboard/wb-hwconf-manager/blob/4eb1ce1dc3db26d07a7241c78cfa456a26d6bbbf/wb-hwconf-helper#L72)

посмотрел по остальным модулям - такого больше нет; думаю, достаточно исправления + таймаута, чтобы под капот сильно не лазить

таймаут достаточно большой, чтобы было заметно, что что-то не так