### PR TITLE
removed local keyword from wb-hwconf-helper

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,18 @@
+wb-hwconf-manager (1.58.2) stable; urgency=medium
+
+  * wb-hwconf-helper: removed local keyword
+
+ -- Maxim Tomchuk <maxim.tomchuk@wirenboard.ru>  Sun, 20 Aug 2023 13:31:38 +0300
+
 wb-hwconf-manager (1.58.1) stable; urgency=medium
 
-  * Supercap: changed voltage thresholds and capacity for correct calculating of % and current 
+  * Supercap: changed voltage thresholds and capacity for correct calculating of % and current
 
  -- Maxim Tomchuk <maxim.tomchuk@wirenboard.ru>  Mon, 14 Aug 2023 18:33:00 +0300
 
 wb-hwconf-manager (1.58.0) stable; urgency=medium
 
-  * Move to device independent config file format 
+  * Move to device independent config file format
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 03 Aug 2023 12:37:07 +0500
 

--- a/wb-hwconf-helper
+++ b/wb-hwconf-helper
@@ -85,7 +85,7 @@ config_apply_changes() {
 		done <<< "$delta"
 		sort "$state" > "$old_state"
 	done
-		
+
 	rm "$old_state"
 	sort "$state" > "$CONFIG_STATE"
 	rm "$state"
@@ -129,17 +129,17 @@ case "$1" in
 		# stdout+stderr must be JSON, so redirect logging to syslog
 		SYSLOG="yes"
 		catch_output config_apply_changes "$tmp"
-		
+
 		cat "$tmp"
 		rm "$tmp"
 		;;
 	"init")
-		local CONFIG="$(config_make_temporary_combined)" || exit 1
+		CONFIG="$(config_make_temporary_combined)" || exit 1
 		module_init $2 $3
 		rm ${CONFIG}
 		;;
 	"deinit")
-		local CONFIG="$(config_make_temporary_combined)" || exit 1
+		CONFIG="$(config_make_temporary_combined)" || exit 1
 		module_deinit $2
 		rm ${CONFIG}
 		;;


### PR DESCRIPTION
В утилите wb-hwconf-helper были `local` которые мешали работе бинарника