### PR TITLE
fix 1-Wire pins for WB7.4+

### DIFF
--- a/boards/wb74x.conf
+++ b/boards/wb74x.conf
@@ -128,7 +128,7 @@
         },
         {
             "slot_id": "w1",
-            "id": "wb72-w1",
+            "id": "wb74-w1",
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
@@ -136,7 +136,7 @@
         },
         {
             "slot_id": "w2",
-            "id": "wb72-w2",
+            "id": "wb74-w2",
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.58.4) stable; urgency=medium
+
+  * Fix 1-Wire pin numbers for Wiren Board 7.4+
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Sat, 11 Nov 2023 00:16:00 +0600
+
 wb-hwconf-manager (1.58.3) stable; urgency=medium
 
   * Ignore unsupported slots and modules in /etc/wb-hardware.conf 

--- a/slots/wb74-w1.def
+++ b/slots/wb74-w1.def
@@ -1,0 +1,11 @@
+#define SLOT_ALIAS	w1
+#define W_SLOT_NUM 1
+
+#define SLOT_DATA	(7, 2)
+#define SLOT_PULLUP	(8, 0)
+
+#define SLOT_1WIRE_ALIAS	&onewire_w1
+#define SLOT_PINCTRL &pinctrl_w1_gpio
+
+#include "wb6-wx.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb74-w2.def
+++ b/slots/wb74-w2.def
@@ -1,0 +1,11 @@
+#define SLOT_ALIAS	w2
+#define W_SLOT_NUM 2
+
+#define SLOT_DATA	(8, 17)
+#define SLOT_PULLUP	(8, 1)
+
+#define SLOT_1WIRE_ALIAS	&onewire_w2
+#define SLOT_PINCTRL &pinctrl_w2_gpio
+
+#include "wb6-wx.h"
+#include "r40-soc.h"  // should be included after SLOT_ALL_PINS is defined


### PR DESCRIPTION
Забыли в момент выпуска wb74 прописать правильные пины для 1-wire (а они там переехали), из-за этого при перенастройке 1-wire отключается питание периферии. Связанный PR в ядро: https://github.com/wirenboard/linux/pull/163