### PR TITLE
Add wb-mqtt-mbgate restart

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.58.6) stable; urgency=medium
+
+  * Add wb-mqtt-mbgate restart at rs485 init hook to reopen the port in this service
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Wed, 20 Dec 2023 16:41:26 +0300
+
 wb-hwconf-manager (1.58.5) stable; urgency=medium
 
   * wbe2-ao-10v-2: add missed iio_device

--- a/modules/wb67-can-rs485.sh
+++ b/modules/wb67-can-rs485.sh
@@ -36,6 +36,8 @@ hook_module_init() {
 		sysfs_gpio_direction $GPIO_CAN_EN out
 		sysfs_gpio_set $GPIO_CAN_EN 0
 	fi;
+
+	systemctl restart wb-mqtt-mbgate.service
 }
 
 hook_module_deinit() {

--- a/modules/wb67-can-rs485.sh
+++ b/modules/wb67-can-rs485.sh
@@ -37,7 +37,7 @@ hook_module_init() {
 		sysfs_gpio_set $GPIO_CAN_EN 0
 	fi;
 
-	systemctl restart wb-mqtt-mbgate.service
+	hook_once_after_config_change "service_restart wb-mqtt-mbgate"
 }
 
 hook_module_deinit() {


### PR DESCRIPTION
В случае, если сервис мбгейт лег вследствие неправильных настроек хвконфа (если был выставлен CAN или UART-CAN), то при выставлении правильной настройки RS485 нужно рестартануть сервис, чтобы он переоткрыл порт - только в этом случае новая настройка будет работать корректно