### PR TITLE
wbe2-ao-10v-2: fix wb-mqtt-dac config fill

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.58.7) stable; urgency=medium
+
+  * wbe2-ao-10v-2: fix wb-mqtt-dac config fill
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 18 Jan 2024 18:50:21 +0300
+
 wb-hwconf-manager (1.58.6) stable; urgency=medium
 
   * Add wb-mqtt-mbgate restart at rs485 init hook to reopen the port in this service

--- a/modules/wbe2-ao-10v-2.sh
+++ b/modules/wbe2-ao-10v-2.sh
@@ -2,8 +2,8 @@ source "$DATADIR/modules/utils.sh"
 local CONFIG_DAC=${CONFIG_DAC:-/var/lib/wb-mqtt-dac/conf.d/system.conf}
 local IIO_OF_NAME="${SLOT_ALIAS}_wbe2_ao_10v_2"
 
-hook_module_add() {
-    local IIO_BUS_NUM=`ls -d /sys/devices/platform/${SLOT_ALIAS}_i2c@0/*/*/iio:device* | grep -Po '(?<=iio:device)(\d+)'`
+hook_module_init() {
+    local IIO_BUS_NUM=`ls -d /sys/devices/platform/${SLOT_ALIAS}_i2c/*/*/iio:device* | grep -Po '(?<=iio:device)(\d+)'`
 
     local JSON=$CONFIG_DAC
     local items=()


### PR DESCRIPTION
add выполняется раньше init -> когда мы собираем конфиг, ядерные дела еще не произошли

в модульке wbeПросто - выглядит ок + до wb5 не долетят изменения + не жаловались => менять не вижу смысла