### PR TITLE
introduce wbmz5-supercap

### DIFF
--- a/modules/wbmz5-supercap.dtso
+++ b/modules/wbmz5-supercap.dtso
@@ -1,0 +1,12 @@
+/ {
+	description = "WBMZ5-SUPERCAP";
+	compatible-slots = "wb84-wbmz5-power";
+
+	fragment-00-dummy-fragment {
+		target = <&battery_power_supply>;
+
+		__overlay__ {
+			// doing nothing; just for compatibility
+		};
+	};
+};


### PR DESCRIPTION
суперкап для WB8 не умеет мерить напряжение => сделали просто, чтобы был в webui