### PR TITLE
wb84: fix WBIO-AI-DV-12 support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.61.1) stable; urgency=medium
+
+  * wb84: fix WBIO-AI-DV-12 support
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Thu, 15 Aug 2024 16:52:14 +0500
+
 wb-hwconf-manager (1.61.0) stable; urgency=medium
 
   * introduce wb85x board config

--- a/slots/wb84-extio.h
+++ b/slots/wb84-extio.h
@@ -26,5 +26,5 @@
 #include "wb-extio-common.h"
 
 #ifdef FROM_SHELL
-local SLOT_I2C_DEVICE_MATCH="1c2b000.i2c"
+local SLOT_I2C_DEVICE_MATCH="5002c00.i2c"
 #endif


### PR DESCRIPTION
просто забыли дописать правильный адрес i2c-шины в hwconf.

на стендике проверил, что контролы перестали быть красными, но настоящее напряжение на них подавать ещё не пробовал, попросил эникейщика.