### PR TITLE
fix wbio interrupts: mcp23xx use int-open-drain option from kernel ma…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-hwconf-manager (1.61.0-wb100) stable; urgency=medium
+
+  * wb8: fix wbio interrupts
+  * internals: mcp23xx use int-open-drain option from kernel mainline by default
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 26 Aug 2024 14:11:32 +0300
+
 wb-hwconf-manager (1.61.0) stable; urgency=medium
 
   * introduce wb85x board config

--- a/modules/wbio.dtsi
+++ b/modules/wbio.dtsi
@@ -18,7 +18,7 @@ EXTIO_FRAGMENT_NAME {
 			__gpio-cells = <2>;
 			reg = <HEX_PREFIX(SLOT_I2C_ADDRESS)>;
 
-			microchip,irq-open-drain;
+			WBIO_INT_OPEN_DRAIN_OPTION;
 
 			interrupt-parent = <SLOT_GPIO_PORT_ALIAS(INT)>;
 			interrupts = <SLOT_GPIO_SPEC(INT) IRQ_TYPE_NONE>;

--- a/modules/wbio16.dtsi
+++ b/modules/wbio16.dtsi
@@ -18,7 +18,7 @@ EXTIO_FRAGMENT_NAME {
 			__gpio-cells = <2>;
 			reg = <HEX_PREFIX(SLOT_I2C_ADDRESS)>;
 
-			microchip,irq-open-drain;
+			WBIO_INT_OPEN_DRAIN_OPTION;
 			microchip,irq-mirror;
 
 			interrupt-parent = <SLOT_GPIO_PORT_ALIAS(INT)>;

--- a/slots/allwinner-soc.h
+++ b/slots/allwinner-soc.h
@@ -32,6 +32,8 @@
 
 #define GPIO_PORT_PIN_TO_NUM(bank, pin) $((bank * 32 + pin))
 
+#define WBIO_INT_OPEN_DRAIN_OPTION drive-open-drain
+
 #include "strutils.h"
 
 #ifdef FROM_SHELL

--- a/slots/imx-common.h
+++ b/slots/imx-common.h
@@ -36,6 +36,8 @@
 #define SLOT_GPIO_XLATE_TYPE(x) "offset"
 #define SLOT_GPIO_PINS_PER_BANK(x) 0
 
+#define WBIO_INT_OPEN_DRAIN_OPTION microchip,irq-open-drain
+
 #include "strutils.h"
 
 #ifdef FROM_SHELL

--- a/slots/r40-soc.h
+++ b/slots/r40-soc.h
@@ -12,3 +12,5 @@
 #ifndef SLOT_VDD_SUPPLY
 #define SLOT_VDD_SUPPLY
 #endif
+
+#define WBIO_INT_OPEN_DRAIN_OPTION microchip,irq-open-drain


### PR DESCRIPTION
…inline by default (#126)

надо и в 2407