### PR TITLE
wb85: fix 1-wire discrete input (#130)

### DIFF
--- a/boards/wb85x.conf
+++ b/boards/wb85x.conf
@@ -128,7 +128,7 @@
         },
         {
             "slot_id": "w1",
-            "id": "wb84-w1",
+            "id": "wb85-w1",
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
@@ -136,7 +136,7 @@
         },
         {
             "slot_id": "w2",
-            "id": "wb84-w2",
+            "id": "wb85-w2",
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",

--- a/boards/wb85xm.conf
+++ b/boards/wb85xm.conf
@@ -64,7 +64,7 @@
         },
         {
             "slot_id": "w1",
-            "id": "wb84-w1",
+            "id": "wb85-w1",
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
@@ -72,7 +72,7 @@
         },
         {
             "slot_id": "w2",
-            "id": "wb84-w2",
+            "id": "wb85-w2",
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.63.1) stable; urgency=medium
+
+  * wb85: fix 1-wire discrete inputs
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 27 Nov 2024 18:02:38 +0300
+
 wb-hwconf-manager (1.63.0) stable; urgency=medium
 
   * add wb85xm board config (metall-body WB without WBIO)

--- a/slots/wb85-w1.def
+++ b/slots/wb85-w1.def
@@ -1,0 +1,11 @@
+#define SLOT_ALIAS	w1
+#define W_SLOT_NUM 1
+
+#define SLOT_DATA	(3, 12)
+#define SLOT_PULLUP	(6, 8)
+
+#define SLOT_1WIRE_ALIAS	&onewire_w1
+#define SLOT_PINCTRL &pinctrl_w1_gpio
+
+#include "wb6-wx.h"
+#include "t507-soc.h"  // should be included after SLOT_ALL_PINS is defined

--- a/slots/wb85-w2.def
+++ b/slots/wb85-w2.def
@@ -1,0 +1,11 @@
+#define SLOT_ALIAS	w2
+#define W_SLOT_NUM 2
+
+#define SLOT_DATA	(3, 24)
+#define SLOT_PULLUP	(4, 21)
+
+#define SLOT_1WIRE_ALIAS	&onewire_w2
+#define SLOT_PINCTRL &pinctrl_w2_gpio
+
+#include "wb6-wx.h"
+#include "t507-soc.h"  // should be included after SLOT_ALL_PINS is defined


### PR DESCRIPTION
бекпорт вот [етого вот](https://github.com/wirenboard/wb-hwconf-manager/pull/130)

мастер не убежал, поэтому без -wb100 всяких
можно было бы просто перетащить ветку, но я форспушить сюда не могу => через PR