### PR TITLE
Feature/wb85 gps

### DIFF
--- a/boards/wb85x.conf
+++ b/boards/wb85x.conf
@@ -3,7 +3,7 @@
         {
             "slot_id": "mod1",
             "id": "wb85-mod1",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart", "wbe3-wbec-only"],
             "name": "Internal slot 1",
             "module": "",
             "options": {}
@@ -11,7 +11,7 @@
         {
             "slot_id": "mod2",
             "id": "wb85-mod2",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart", "wbe3-wbec-only"],
             "name": "Internal slot 2",
             "module": "",
             "options": {}

--- a/boards/wb85xm.conf
+++ b/boards/wb85xm.conf
@@ -3,7 +3,7 @@
         {
             "slot_id": "mod1",
             "id": "wb85-mod1",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart", "wbe3-wbec-only"],
             "name": "Internal slot 1",
             "module": "",
             "options": {}
@@ -11,7 +11,7 @@
         {
             "slot_id": "mod2",
             "id": "wb85-mod2",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe3-reduced-uart", "wbe3-wbec-only"],
             "name": "Internal slot 2",
             "module": "",
             "options": {}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.64.0) stable; urgency=medium
+
+  * wb85, wb85m: make gps module compatible with MOD1 & 2 slots (without pps signal)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 11 Dec 2024 14:28:12 +0300
+
 wb-hwconf-manager (1.63.1) stable; urgency=medium
 
   * wb85: fix 1-wire discrete inputs

--- a/modules/wbe3-r-gps-no-pps.dtso
+++ b/modules/wbe3-r-gps-no-pps.dtso
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Contactless Devices, LLC.
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/ {
+	description = "WBE3-R-GPS: GPS/GLONASS Receiver (without PPS signal)";
+	compatible-slots = "wbe3-wbec-only";
+
+	fragment@0 {
+		target = <SLOT_UART_ALIAS>;
+
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <SLOT_TXRX_UART_PINCTRL>;
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
В wb85 для MOD1 и 2 gps-модулёк не делали, пот wbec не умеет в прерывания на gpio => не будет работать pps

но @evgeny-boger предложил сделать на mod1 и mod2 gps без pps
![image](https://github.com/user-attachments/assets/c4dee784-c855-4ba5-9a91-07dcbfe398a1)
я проверил, NMEA-сообщения бегут