### PR TITLE
wb84: rename supercap module

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.64.1) stable; urgency=medium
+
+  * wb84: rename supercap module
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 11 Dec 2024 17:57:21 +0300
+
 wb-hwconf-manager (1.64.0) stable; urgency=medium
 
   * wb85, wb85m: make gps module compatible with MOD1 & 2 slots (without pps signal)

--- a/modules/wbmz5-supercap.dtso
+++ b/modules/wbmz5-supercap.dtso
@@ -1,5 +1,5 @@
 / {
-	description = "WBMZ5-SUPERCAP";
+	description = "WBMZ4-SUPERCAP";
 	compatible-slots = "wb84-wbmz5-power";
 
 	fragment-00-dummy-fragment {


### PR DESCRIPTION
Оказывается, wbmz5-supercap в природе нет (а когда делали софт - видимо, предполагали) => переименовал
https://wirenboard.youtrack.cloud/issue/FW-770/Oshibka-nejminga-vnutrennego-modulya-WBMZ5-SUPERCAP

название самого модуля менять не стал, чтобы пользователям обновлением ничего не ломать