### PR TITLE
Enable coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 buildDebArchAll defaultRunLintian: true,
                 defaultRunPythonChecks: true,
-                defaultAngryPylint: true
+                defaultAngryPylint: true,
+                defaultRunCoverage: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 buildDebArchAll defaultRunLintian: true,
                 defaultRunPythonChecks: true,
                 defaultAngryPylint: true,
-                defaultRunCoverage: true
+                defaultRunCoverage: true,
+                defaultCoverageMin: "81"
+

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,6 @@ install: install_data
 	install -Dm0644 wb-hardware.conf $(DESTDIR)/etc/wb-hardware.conf
 
 test:
-	python3 -m pytest -vv
+	python3 -m pytest -vv $(PYBUILD_TEST_ARGS)
 
 .PHONY: install install_data all test

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ modules_schema_part = modules/*.schema.json
 hidden_modules_schema_part = modules/hidden_modules.json
 hidden_modules = $(shell jq -cM '.hidden_from_webui' $(hidden_modules_schema_part))
 
+processed_pybuild_test_args = $(shell echo $(PYBUILD_TEST_ARGS) | sed -E "s|--cov-config=[^ ]+|--cov-config=coveragerc|")
+
 all:
 	@echo "Nothing to do"
 
@@ -36,6 +38,6 @@ install: install_data
 	install -Dm0644 wb-hardware.conf $(DESTDIR)/etc/wb-hardware.conf
 
 test:
-	python3 -m pytest -vv $(PYBUILD_TEST_ARGS)
+	python3 -m pytest -vv $(processed_pybuild_test_args)
 
 .PHONY: install install_data all test

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.66.1) stable; urgency=medium
+
+  * Enable python coverage
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 24 Feb 2025 10:43:32 +0300
+
 wb-hwconf-manager (1.66.0) stable; urgency=medium
 
   * Add vendor customization


### PR DESCRIPTION
К сожалению в этом месте у нас со сборкой не все хорошо. Так как через buildDebArchAll собираются пакеты в основном через pybuild, а здесь через make, то путь к coveragerc отличается. 