### PR TITLE
Features/soft 5569 hdmi module

### DIFF
--- a/boards/wb85x.conf
+++ b/boards/wb85x.conf
@@ -27,7 +27,7 @@
         {
             "slot_id": "mod4",
             "id": "wb85-mod4",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-hdmi"],
             "name": "Internal slot 4",
             "module": "",
             "options": {}

--- a/modules/wbe2-hdmi.dtso
+++ b/modules/wbe2-hdmi.dtso
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2016 Contactless Devices, LLC.
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/ {
+    description = "WBE2-HDMI: HDMI output";
+    compatible-slots = "wbe2-hdmi";
+};

--- a/modules/wbe2-hdmi.schema.json
+++ b/modules/wbe2-hdmi.schema.json
@@ -1,0 +1,60 @@
+{
+  "module_wbe2-hdmi": {
+    "title": "WBE2-HDMI module configuration",
+    "type": "object",
+    "properties": {
+      "mode": {
+        "type": "string",
+        "title": "Mode",
+        "enum": ["separate"],
+        "default": "separate",
+        "options": {
+          "hidden": true
+        },
+        "propertyOrder": 1
+      },
+      "channels": {
+        "type": "array",
+        "title": "Channels",
+        "minItems": 12,
+        "maxItems": 12,
+        "_format": "tabs",
+        "items": {
+          "type": "object",
+          "title": "Channel options",
+          "headerTemplate": "Channel A{{i1}}",
+          "options": {
+            "disable_collapse": true
+          },
+          "properties": {
+            "mode": {
+              "type": "string",
+              "title": "Mode",
+              "minLength": 1,
+              "enumSource": [{
+                "source": [
+                  { "value": "voltage", "title": "Voltage, 0-2.5 V" },
+                  { "value": "voltage_pm50", "title": "Voltage +/-50V" },
+                  { "value": "current_20ma", "title": "Current 0-20mA" }
+                ],
+                "value": "{{item.value}}",
+                "title": "{{item.title}}"
+              }],
+              "default": "voltage_pm50",
+              "propertyOrder": 1
+            }
+          },
+          "required": ["mode"]
+        },
+        "options": {
+          "disable_collapse": true,
+          "disable_array_add": true,
+          "disable_array_delete": true,
+          "disable_array_reorder": true
+        },
+        "propertyOrder": 2
+      }
+    },
+    "required": ["mode", "channels"]
+  }
+}

--- a/modules/wbe2-hdmi.schema.json
+++ b/modules/wbe2-hdmi.schema.json
@@ -5,47 +5,46 @@
     "properties": {
       "mode": {
         "type": "string",
-        "title": "Mode",
-        "enum": ["separate"],
-        "default": "separate",
+        "title": "Resolution",
+        "minLength": 1,
+        "watch": { "available_hdmi_modes": "available_hdmi_modes" },
+        "enumSource": [
+          {
+            "source": [{ "title": "AUTO from EDID", "value": "auto" }],
+            "title": "{{item.title}}",
+            "value": "{{item.value}}"
+          },
+          {
+            "source": "available_hdmi_modes",
+            "title": "{{item.title}}",
+            "value": "{{item.value}}"
+          }
+        ],
+        "default": "auto",
         "options": {
-          "hidden": true
+          "disable_collapse": true,
+          "disable_array_add": true,
+          "disable_array_delete": true,
+          "disable_array_reorder": true
         },
         "propertyOrder": 1
       },
-      "channels": {
-        "type": "array",
-        "title": "Channels",
-        "minItems": 12,
-        "maxItems": 12,
-        "_format": "tabs",
-        "items": {
-          "type": "object",
-          "title": "Channel options",
-          "headerTemplate": "Channel A{{i1}}",
-          "options": {
-            "disable_collapse": true
-          },
-          "properties": {
-            "mode": {
-              "type": "string",
-              "title": "Mode",
-              "minLength": 1,
-              "enumSource": [{
-                "source": [
-                  { "value": "voltage", "title": "Voltage, 0-2.5 V" },
-                  { "value": "voltage_pm50", "title": "Voltage +/-50V" },
-                  { "value": "current_20ma", "title": "Current 0-20mA" }
-                ],
-                "value": "{{item.value}}",
-                "title": "{{item.title}}"
-              }],
-              "default": "voltage_pm50",
-              "propertyOrder": 1
-            }
-          },
-          "required": ["mode"]
-        },
+      "rotate": {
+        "type": "string",
+        "title": "Rotate",
+        "enumSource": [
+          {
+            "source": [
+              { "title": "0°", "value": "0" },
+              { "title": "90°", "value": "90" },
+              { "title": "180°", "value": "180" },
+              { "title": "270°", "value": "270" }
+            ],
+            "title": "{{item.title}}",
+            "value": "{{item.value}}"
+          }
+        ],
+        "default": "0",
         "options": {
           "disable_collapse": true,
           "disable_array_add": true,
@@ -53,8 +52,16 @@
           "disable_array_reorder": true
         },
         "propertyOrder": 2
+      },
+      "url": {
+        "type": "string",
+        "title": "Autoloaded URL from FireFox",
+        "minLength": 10,
+        "default": "http://localhost",
+        "format": "uri",
+        "propertyOrder": 3
       }
     },
-    "required": ["mode", "channels"]
+    "required": ["mode", "rotate", "url"]
   }
 }

--- a/modules/wbe2-hdmi.sh
+++ b/modules/wbe2-hdmi.sh
@@ -1,0 +1,70 @@
+source "$DATADIR/modules/utils.sh"
+
+local CONFIG_ADC=${CONFIG_ADC:-/etc/wb-mqtt-adc.conf}
+local I2C_ADDR=48
+
+hook_module_add() {
+	local JSON=$CONFIG_ADC
+	local items=()
+	local chan mul max_voltage
+	for chan in 0 1; do
+		local gain="$(config_module_option ".channels[$chan].gain // 1")"
+		case "$(config_module_option ".channels[$chan].mode // \"voltage\"")" in
+			voltage)
+				mul=1
+				;;
+			voltage_x10)
+				mul=10
+				;;
+			current)
+				mul=0.02004
+				;;
+		esac
+		items+=( "{
+			id: \"MOD${SLOT_NUM}_A$((chan+1))\",
+			averaging_window: 1,
+			match_iio: \"mod${SLOT_NUM}_i2c\",
+			channel_number: $chan,
+			voltage_multiplier: (${mul}*${gain}),
+			decimal_places: 3,
+			max_voltage: 3.3
+		}" )
+		shift 3
+	done
+	json_array_append ".iio_channels" "${items[@]}"
+
+	hook_once_after_config_change "service_restart_delete_retained wb-mqtt-adc /devices/wb-adc/#"
+}
+
+hook_module_del() {
+	local JSON=$CONFIG_ADC
+	json_array_delete ".iio_channels" \
+		". as \$chan | ([\"MOD${SLOT_NUM}_A1\", \"MOD${SLOT_NUM}_A2\"] | map(. == \$chan.id) | any)"
+	hook_once_after_config_change "service_restart_delete_retained wb-mqtt-adc /devices/wb-adc/#"
+}
+
+hook_module_init() {
+	local bus=$(slot_i2c_bus_sysfs)
+	[[ -d "$bus" ]] || {
+		log "Unable to find i2c bus for slot $SLOT (sysfs: $bus)"
+		return 1
+	}
+	echo "ads1015 0x${I2C_ADDR}" > $bus/new_device
+
+	local dev=$(slot_i2c_dev_sysfs $I2C_ADDR)
+	wait_for_path "$dev"
+
+	local chan
+	for chan in 0 1; do
+		config_module_option ".channels[$chan].gain // 1" > $(echo "$dev/iio:device"*"/in_voltage${chan}_scale")
+	done
+}
+
+hook_module_deinit() {
+	local bus=$(slot_i2c_bus_sysfs)
+	[[ -d "$bus" ]] || {
+		log "Unable to find i2c bus for slot $SLOT (sysfs: $bus)"
+		return 1
+	}
+	echo "0x${I2C_ADDR}" > $bus/delete_device
+}


### PR DESCRIPTION
Добавлена поддержка HDMI-настроек в конфигуратор

- В config.py реализовано чтение доступных HDMI-режимов из /sys/class/drm/card0-HDMI-A-1/modes
  - Исключаются дублирующиеся и interlaced-режимы при наличии прогрессивных
  - Список сортируется по разрешению и передаётся в available_hdmi_modes

- В wbe2-hdmi.schema.json:
  - Заменено поле mode на Resolution с enumSource (AUTO + динамически загружаемые режимы)
  - Добавлено поле Rotate с предустановленными значениями (0, 90, 180, 270)
  - Добавлено поле URL с валидацией как URI и значением по умолчанию http://localhost
  - Поля mode, rotate и url сделаны обязательными