### PR TITLE
Features/hdmi disable overlay

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.68.2) stable; urgency=medium
+
+  * modules/wbe2-hdmi.dtso: switch to dummy overlay; HDMI enabled statically
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Fri, 15 Aug 2025 09:57:40 +0300
+
 wb-hwconf-manager (1.68.1) stable; urgency=medium
 
   * Add FullHD resolutin for HDMI

--- a/modules/wbe2-hdmi.dtso
+++ b/modules/wbe2-hdmi.dtso
@@ -14,16 +14,12 @@
     compatible-slots = "wbe2-hdmi";
 
     fragment@0 {
-        target = <&de>;
+        target-path = "/";
         __overlay__ {
-            status = "okay";
-        };
-    };
-
-    fragment@1 {
-        target = <&hdmi>;
-        __overlay__ {
-            status = "okay";
+            wb-overlay-meta {
+                status = "okay";
+                overlay-id = "wbe2-hdmi";
+            };
         };
     };
 };

--- a/modules/wbe2-hdmi.dtso
+++ b/modules/wbe2-hdmi.dtso
@@ -13,12 +13,14 @@
     description = "WBE2-HDMI: HDMI interface";
     compatible-slots = "wbe2-hdmi";
 
+    /* HDMI is enabled statically in the base DTS; this .dtso is a dummy overlay for UI metadata. */
+    /* The wb-overlay-meta node under "/" creates a non-empty changeset and prevents WARNs on overlay removal. */
     fragment@0 {
         target-path = "/";
         __overlay__ {
-            wb-overlay-meta {
+            wb-hdmi-overlay-dummy {
                 status = "okay";
-                overlay-id = "wbe2-hdmi";
+                overlay-id = "wbe2-hdmi-dummy";
             };
         };
     };


### PR DESCRIPTION
**Что происходит; кому и зачем нужно:**

Отключил дерганье оверлеями.

HDMI (&de, &hdmi) теперь постоянно включены в базовой DTS, поэтому
функциональные фрагменты в .dtso не нужны. Однако «пустой» оверлей
вызывал WARN при снятии через configfs (kobject_put()/refcount
underflow в of_overlay_remove/free_overlay_changeset).

Добавлен безопасный псевдо-оверлей: один fragment с target-path="/" и
служебным узлом wb-overlay-meta. Это создаёт ненулевой changeset,
корректно откатывается при удалении и сохраняет метаданные
(description/compatible-slots) для отображения модуля в UI.

___________________________________
**Что поменялось для пользователей:**
Поведение железа не меняется.

___________________________________
**Как проверял/а:**
На WB8.5 в dmesg чистенько при дерганьи модулем

