### PR TITLE
Feauture/hdmi weston clean

### DIFF
--- a/config.py
+++ b/config.py
@@ -443,4 +443,4 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ wb-hwconf-manager (1.71.2) stable; urgency=medium
   * HDMI:
     - switch runtime hooks from Xorg to Wayland
     - detect EDID on the first connected HDMI connector
+    - use wb-sway-kiosk package and service for Wayland runtime
 
  -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 17 Mar 2026 00:00:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-hwconf-manager (1.71.2) stable; urgency=medium
+
+  * HDMI:
+    - switch runtime hooks from Xorg to Wayland
+    - detect EDID on the first connected HDMI connector
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 17 Mar 2026 00:00:00 +0000
+
 wb-hwconf-manager (1.71.1) stable; urgency=medium
 
   * wb85x: fix wrong gpio numbers resolving in mod1 & mod2 slots

--- a/hdmi.py
+++ b/hdmi.py
@@ -122,39 +122,31 @@ def _read_current_resolution() -> str:
 
     encoder_to_crtc: Dict[str, str] = {}
     hdmi_encoder = ""
-    in_encoders = False
-    in_connectors = False
-    in_crtcs = False
+    section = ""
 
     for raw_line in txt.splitlines():
         line = raw_line.rstrip()
         stripped = line.strip()
 
         if stripped.startswith("Encoders:"):
-            in_encoders = True
-            in_connectors = False
-            in_crtcs = False
+            section = "encoders"
             continue
         if stripped.startswith("Connectors:"):
-            in_encoders = False
-            in_connectors = True
-            in_crtcs = False
+            section = "connectors"
             continue
         if stripped.startswith("CRTCs:"):
-            in_encoders = False
-            in_connectors = False
-            in_crtcs = True
+            section = "crtcs"
             continue
         if not stripped:
             continue
 
-        if in_encoders:
+        if section == "encoders":
             parts = stripped.split()
             if len(parts) >= 2 and parts[0].isdigit():
                 encoder_to_crtc[parts[0]] = parts[1]
             continue
 
-        if in_connectors:
+        if section == "connectors":
             parts = stripped.split()
             if len(parts) >= 4 and parts[0].isdigit() and parts[1].isdigit():
                 if parts[2] == "connected" and parts[3].startswith("HDMI-A-"):
@@ -162,7 +154,7 @@ def _read_current_resolution() -> str:
                     continue
             continue
 
-        if in_crtcs and hdmi_encoder:
+        if section == "crtcs" and hdmi_encoder:
             crtc_id = encoder_to_crtc.get(hdmi_encoder, "")
             parts = stripped.split()
             if len(parts) >= 4 and crtc_id and parts[0] == crtc_id:

--- a/hdmi.py
+++ b/hdmi.py
@@ -442,7 +442,7 @@ def get_hdmi_modes() -> List[Dict[str, str]]:
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
-    installed = _is_installed("wb-hdmi") or _is_installed("wb-hdmi-wayland")
+    installed = _is_installed("wb-hdmi") or _is_installed("wb-sway-kiosk")
 
     out: List[Dict[str, str]] = []
 
@@ -454,7 +454,7 @@ def get_hdmi_modes() -> List[Dict[str, str]]:
         # Expose a single message in case any UI watches available_hdmi_modes
         msg = (
             "To use the graphical interface, you need to install the "
-            "wb-hdmi or wb-hdmi-wayland package: apt install wb-hdmi"
+            "wb-hdmi or wb-sway-kiosk package: apt install wb-hdmi"
         )
         out.append({"value": "auto", "title": msg})
 

--- a/hdmi.py
+++ b/hdmi.py
@@ -114,7 +114,47 @@ def _parse_modetest_modes() -> List[Dict[str, object]]:
     return modes
 
 
-def _read_current_resolution() -> str:  # pylint: disable=too-many-branches
+def _modetest_section_name(stripped: str) -> str:
+    """Return current modetest section name or an empty string."""
+    if stripped.startswith("Encoders:"):
+        return "encoders"
+    if stripped.startswith("Connectors:"):
+        return "connectors"
+    if stripped.startswith("CRTCs:"):
+        return "crtcs"
+    return ""
+
+
+def _parse_encoder_line(stripped: str) -> Tuple[str, str]:
+    """Return encoder->CRTC mapping from a modetest line."""
+    parts = stripped.split()
+    if len(parts) >= 2 and parts[0].isdigit():
+        return parts[0], parts[1]
+    return "", ""
+
+
+def _parse_connected_hdmi_encoder(stripped: str) -> str:
+    """Return HDMI encoder id from a connected connector line."""
+    parts = stripped.split()
+    if len(parts) >= 4 and parts[0].isdigit() and parts[1].isdigit():
+        if parts[2] == "connected" and parts[3].startswith("HDMI-A-"):
+            return parts[1]
+    return ""
+
+
+def _parse_crtc_resolution(stripped: str, crtc_id: str) -> Optional[str]:
+    """Return active resolution from a CRTC line for the selected encoder."""
+    parts = stripped.split()
+    if len(parts) < 4 or not crtc_id or parts[0] != crtc_id:
+        return None
+
+    size = parts[3].strip("()")
+    if size and size != "0x0":
+        return size
+    return ""
+
+
+def _read_current_resolution() -> str:
     """Return current active HDMI resolution from modetest CRTC state."""
     txt = _run_modetest_full()
     if not txt:
@@ -128,40 +168,27 @@ def _read_current_resolution() -> str:  # pylint: disable=too-many-branches
         line = raw_line.rstrip()
         stripped = line.strip()
 
-        if stripped.startswith("Encoders:"):
-            section = "encoders"
-            continue
-        if stripped.startswith("Connectors:"):
-            section = "connectors"
-            continue
-        if stripped.startswith("CRTCs:"):
-            section = "crtcs"
+        if new_section := _modetest_section_name(stripped):
+            section = new_section
             continue
         if not stripped:
             continue
 
         if section == "encoders":
-            parts = stripped.split()
-            if len(parts) >= 2 and parts[0].isdigit():
-                encoder_to_crtc[parts[0]] = parts[1]
+            encoder_id, crtc_id = _parse_encoder_line(stripped)
+            if encoder_id:
+                encoder_to_crtc[encoder_id] = crtc_id
             continue
 
         if section == "connectors":
-            parts = stripped.split()
-            if len(parts) >= 4 and parts[0].isdigit() and parts[1].isdigit():
-                if parts[2] == "connected" and parts[3].startswith("HDMI-A-"):
-                    hdmi_encoder = parts[1]
-                    continue
+            hdmi_encoder = _parse_connected_hdmi_encoder(stripped) or hdmi_encoder
             continue
 
         if section == "crtcs" and hdmi_encoder:
             crtc_id = encoder_to_crtc.get(hdmi_encoder, "")
-            parts = stripped.split()
-            if len(parts) >= 4 and crtc_id and parts[0] == crtc_id:
-                size = parts[3].strip("()")
-                if size and size != "0x0":
-                    return size
-                return ""
+            resolution = _parse_crtc_resolution(stripped, crtc_id)
+            if resolution is not None:
+                return resolution
 
     return ""
 

--- a/hdmi.py
+++ b/hdmi.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import glob
 import os
 import re
 import subprocess
@@ -13,6 +14,14 @@ def _run_modetest() -> str:
     """
     try:
         return subprocess.check_output(["modetest", "-M", "sun4i-drm", "-c"], text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def _run_modetest_full() -> str:
+    """Return stdout of full `modetest -M sun4i-drm` or an empty string."""
+    try:
+        return subprocess.check_output(["modetest", "-M", "sun4i-drm"], text=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
         return ""
 
@@ -105,13 +114,92 @@ def _parse_modetest_modes() -> List[Dict[str, object]]:
     return modes
 
 
+def _read_current_resolution() -> str:
+    """Return current active HDMI resolution from modetest CRTC state."""
+    txt = _run_modetest_full()
+    if not txt:
+        return ""
+
+    encoder_to_crtc: Dict[str, str] = {}
+    hdmi_encoder = ""
+    in_encoders = False
+    in_connectors = False
+    in_crtcs = False
+
+    for raw_line in txt.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+
+        if stripped.startswith("Encoders:"):
+            in_encoders = True
+            in_connectors = False
+            in_crtcs = False
+            continue
+        if stripped.startswith("Connectors:"):
+            in_encoders = False
+            in_connectors = True
+            in_crtcs = False
+            continue
+        if stripped.startswith("CRTCs:"):
+            in_encoders = False
+            in_connectors = False
+            in_crtcs = True
+            continue
+        if not stripped:
+            continue
+
+        if in_encoders:
+            parts = stripped.split()
+            if len(parts) >= 2 and parts[0].isdigit():
+                encoder_to_crtc[parts[0]] = parts[1]
+            continue
+
+        if in_connectors:
+            parts = stripped.split()
+            if len(parts) >= 4 and parts[0].isdigit() and parts[1].isdigit():
+                if parts[2] == "connected" and parts[3].startswith("HDMI-A-"):
+                    hdmi_encoder = parts[1]
+                    continue
+            continue
+
+        if in_crtcs and hdmi_encoder:
+            crtc_id = encoder_to_crtc.get(hdmi_encoder, "")
+            parts = stripped.split()
+            if len(parts) >= 4 and crtc_id and parts[0] == crtc_id:
+                size = parts[3].strip("()")
+                if size and size != "0x0":
+                    return size
+                return ""
+
+    return ""
+
+
 def _clean_monitor_field(text: str) -> str:
     """Trim whitespace/quotes from EDID-decoded strings."""
     return text.replace("'", "").strip()
 
 
-def _read_monitor_name(edid_path: str = "/sys/class/drm/card0-HDMI-A-1/edid") -> str:
+def _find_connected_hdmi_edid() -> str:
+    """Return EDID path for the first connected HDMI connector."""
+    for status_path in sorted(glob.glob("/sys/class/drm/card*-HDMI-A-*/status")):
+        try:
+            with open(status_path, "r", encoding="utf-8") as status_file:
+                if status_file.read().strip() != "connected":
+                    continue
+        except OSError:
+            continue
+
+        edid_path = os.path.join(os.path.dirname(status_path), "edid")
+        if os.path.exists(edid_path):
+            return edid_path
+
+    return ""
+
+
+def _read_monitor_name(edid_path: Optional[str] = None) -> str:
     """Return monitor name parsed from EDID via edid-decode."""
+    if edid_path is None:
+        edid_path = _find_connected_hdmi_edid()
     if not os.path.exists(edid_path):
         return ""
     try:
@@ -173,14 +261,22 @@ def _max_resolution_from_modes(modes: List[Dict[str, object]]) -> str:
     return best_res
 
 
-def get_monitor_info() -> Dict[str, str]:
+def get_monitor_info() -> str:
     """Return basic info about the connected monitor for display in the UI."""
     modes = _parse_modetest_modes()
     max_res = _max_resolution_from_modes(modes)
+    current_res = _read_current_resolution()
     name = _read_monitor_name()
 
     if name:
-        return f"{name} (max: {max_res})"
+        details = []
+        if max_res:
+            details.append(f"max: {max_res}")
+        if current_res:
+            details.append(f"current: {current_res}")
+        if details:
+            return f"{name} ({', '.join(details)})"
+        return name
 
     return "No monitor detected"
 
@@ -221,98 +317,43 @@ def _strip_name_from_modeline_payload(payload: str) -> str:
     return payload
 
 
-def _tokenize_rates(tail: str) -> List[str]:
-    """Extract numeric refresh tokens from a xrandr mode tail string.
+def _build_basic_entries(modes: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    """Build unique flat resolution entries from modetest data."""
+    entries: List[Dict[str, object]] = []
+    seen = set()
 
-    Stops when another resolution-like token appears. Strips trailing non-digit
-    characters except dot.
-    """
-    rates: List[str] = []
-    for tok in tail.split():
-        rt = tok.strip()
-        if "x" in rt:
-            break
-        while rt and not (rt[-1].isdigit() or rt[-1] == "."):
-            rt = rt[:-1]
-        if not rt or not rt[0].isdigit():
+    def res_key(res: str) -> Tuple[int, int]:
+        try:
+            w, h = map(int, res.split("x"))
+        except (ValueError, TypeError):
+            return (0, 0)
+        return (w, h)
+
+    unique_modes = sorted(
+        {
+            str(mode.get("res", ""))
+            for mode in modes
+            if str(mode.get("res", "")) and "x" in str(mode.get("res", ""))
+        },
+        key=res_key,
+        reverse=True,
+    )
+
+    for res in unique_modes:
+        if res in seen:
             continue
-        rates.append(rt)
-    return rates
+        seen.add(res)
+        entries.append(
+            {
+                "kind": "mode",
+                "value": res,
+                "title": res,
+                "name": res,
+                "payload": "",
+            }
+        )
 
-
-def _choose_xrandr_block(blocks: Dict[str, Dict[str, List[str]]], output_name: str) -> Dict[str, List[str]]:
-    """Choose a preferred output block.
-
-    Priority: explicit output_name, then any HDMI*, then first by name.
-    """
-    if output_name in blocks:
-        return blocks[output_name]
-    for name, sub in blocks.items():
-        if name.startswith("HDMI"):
-            return sub
-    if blocks:
-        first_name = sorted(blocks.keys())[0]
-        return blocks[first_name]
-    return {}
-
-
-def _parse_xrandr_modes(output_name: str = "HDMI-1") -> Dict[str, List[str]]:
-    """Collect available resolutions and their refresh rates from `xrandr --query`.
-
-    Returns a mapping {"WxH": ["RR", ...]}. Entries added via --newmode are skipped.
-
-    If xrandr is unavailable (no DISPLAY or binary missing), gracefully fall back to
-    resolutions derived from EDID via modetest, returning unique WxH keys with empty
-    rate lists. This preserves the section in CLI and Web UI.
-    """
-
-    def _from_modetest_fallback() -> Dict[str, List[str]]:
-        result: Dict[str, List[str]] = {}
-        for m in _parse_modetest_modes():
-            res = str(m.get("res", ""))
-            if res:
-                result.setdefault(res, [])
-        return result
-
-    os.environ.setdefault("DISPLAY", ":0.0")
-    try:
-        txt = subprocess.check_output(["xrandr", "--query"], text=True, stderr=subprocess.DEVNULL)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return _from_modetest_fallback()
-
-    # Parse only the requested output block. If not found, fall back to first connected.
-    blocks: Dict[str, Dict[str, List[str]]] = {}
-    current: Optional[str] = None
-    for line in txt.splitlines():
-        if not line:
-            continue
-        if not line.startswith(" "):
-            # Header line: "<OUTPUT> connected ..." or "<OUTPUT> disconnected"
-            current = None
-            name = line.split()[0]
-            if " connected" in line:
-                current = name
-                blocks.setdefault(current, {})
-            continue
-        if not current:
-            continue
-        s = line.strip()
-        if not s:
-            continue
-        first = s.split()[0]
-        # Skip modelines and meta
-        if "-" in first or "x" not in first:
-            continue
-        res = first
-        tail = s[len(first) :].strip()
-        rates = _tokenize_rates(tail)
-        if rates:
-            blocks[current].setdefault(res, rates)
-
-    chosen = _choose_xrandr_block(blocks, output_name)
-    if chosen:
-        return chosen
-    return _from_modetest_fallback()
+    return entries
 
 
 def _make_edid_entry(name: str, info: Dict[str, object], e: Dict[str, object]) -> Dict[str, object]:
@@ -397,7 +438,7 @@ def _build_grouped_entries() -> List[Dict[str, object]]:
 
     Groups consist of:
       - one Auto entry (preferred EDID)
-      - XRANDR resolutions without rates
+      - flat resolutions from modetest
       - detailed EDID/CVT for resolutions >= 2560px width
     """
     entries: List[Dict[str, object]] = []
@@ -426,26 +467,7 @@ def _build_grouped_entries() -> List[Dict[str, object]]:
             }
         )
 
-    # XRANDR entries
-    xr = _parse_xrandr_modes("HDMI-1")
-
-    def res_key(res: str) -> Tuple[int, int]:
-        try:
-            w, h = map(int, res.split("x"))
-        except (ValueError, TypeError):
-            return (0, 0)
-        return (w, h)
-
-    for res in sorted(xr.keys(), key=res_key, reverse=True):
-        entries.append(
-            {
-                "kind": "xrandr",
-                "value": res,
-                "title": res,
-                "name": res,
-                "payload": "",
-            }
-        )
+    entries.extend(_build_basic_entries(modes))
 
     # Detailed EDID/CVT entries
     entries.extend(_build_detailed_entries(modes))
@@ -456,16 +478,19 @@ def _build_grouped_entries() -> List[Dict[str, object]]:
 def get_hdmi_modes() -> List[Dict[str, str]]:
     """Return modes for the Web UI combobox.
 
-    Includes XRANDR resolutions (no rate) and detailed >2K EDID/CVT entries with
+    Includes flat modetest resolutions and detailed >2K EDID/CVT entries with
     unique values (value suffix encodes the timing source and pixel clock).
     May include the Auto entry depending on upstream grouping logic.
     """
-    installed = False
-    try:
-        out = subprocess.check_output(["dpkg-query", "-W", "-f=${Status}", "wb-hdmi"], text=True)
-        installed = "install ok installed" in out
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        installed = False
+
+    def _is_installed(package: str) -> bool:
+        try:
+            out = subprocess.check_output(["dpkg-query", "-W", "-f=${Status}", package], text=True)
+            return "install ok installed" in out
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+
+    installed = _is_installed("wb-hdmi") or _is_installed("wb-hdmi-xorg")
 
     out: List[Dict[str, str]] = []
 
@@ -492,43 +517,12 @@ def _modeline_from_mode(m: Dict[str, object]) -> str:
     )
 
 
-def _ensure_mode_present(output: str, mode_name: str, modeline_payload: str) -> None:
-    """Ensure a mode is known to xrandr: create with --newmode and add to output.
+def _apply_by_index(index_str: str) -> int:
+    """Print a Modeline payload for the selected entry when available.
 
-    No-op when the mode already exists. Requires X server (uses DISPLAY=:0.0).
-    """
-    os.environ.setdefault("DISPLAY", ":0.0")
-    try:
-        out = subprocess.check_output(["xrandr"], text=True, stderr=subprocess.DEVNULL)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        out = ""
-    if mode_name in out:
-        return
-    parts = modeline_payload.split()
-    if not parts:
-        return
-    name_quoted = parts[0]
-    rest = parts[1:]
-    subprocess.run(
-        ["xrandr", "--newmode", name_quoted.strip('"')] + rest,
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    subprocess.run(
-        ["xrandr", "--addmode", output, mode_name],
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-
-
-def _apply_by_index(index_str: str, output: str = "HDMI-1") -> int:
-    """Apply an entry selected by its printed index.
-
-    0 selects Auto (xrandr --auto). Positive indices map to the printed list
-    order: XRANDR resolutions first, then detailed EDID/CVT. Prints the Modeline
-    for detailed entries. Returns a shell-like exit code (0 on success).
+    0 selects the preferred EDID mode. Positive indices map to the printed list
+    order: flat resolutions first, then detailed EDID/CVT entries.
+    Returns a shell-like exit code (0 on success).
     """
     entries = _build_grouped_entries()
     try:
@@ -537,46 +531,22 @@ def _apply_by_index(index_str: str, output: str = "HDMI-1") -> int:
         print("Invalid index", file=sys.stderr)
         return 2
     if idx == 0:
-        os.environ.setdefault("DISPLAY", ":0.0")
-        subprocess.run(
-            ["xrandr", "--output", output, "--auto"],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
         if entries and entries[0].get("payload"):
             print(str(entries[0]["payload"]))
         return 0
-    # Flatten selection order: xrandr first, then detailed
+    # Flatten selection order: flat resolutions first, then detailed
     filtered: List[Dict[str, object]] = []
-    filtered.extend([e for e in entries if e.get("kind") == "xrandr"])
+    filtered.extend([e for e in entries if e.get("kind") == "mode"])
     filtered.extend([e for e in entries if e.get("kind") in {"edid", "cvt"}])
     if idx < 1 or idx > len(filtered):
         print("Index out of range", file=sys.stderr)
         return 2
     e = filtered[idx - 1]
     kind = str(e.get("kind"))
-    os.environ.setdefault("DISPLAY", ":0.0")
-    if kind == "xrandr":
-        res = str(e["name"])  # WxH
-        subprocess.run(
-            ["xrandr", "--output", output, "--mode", res],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+    if kind == "mode":
         return 0
     # detailed edid/cvt
-    ml = str(e["payload"])  # full Modeline
-    name = str(e["name"])  # WxH-RR
-    _ensure_mode_present(output, name, ml)
-    print(ml)
-    subprocess.run(
-        ["xrandr", "--output", output, "--mode", name],
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    print(str(e["payload"]))
     return 0
 
 
@@ -591,9 +561,9 @@ def main() -> int:
         print("0 - auto")
         entries = _build_grouped_entries()
         i = 1
-        # xrandr resolutions first
+        # flat resolutions first
         for e in entries:
-            if e.get("kind") == "xrandr":
+            if e.get("kind") == "mode":
                 print(f"{i} - {e['title']}")
                 i += 1
         # detailed EDID/CVT entries next

--- a/hdmi.py
+++ b/hdmi.py
@@ -456,10 +456,7 @@ def get_hdmi_modes() -> List[Dict[str, str]]:
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
-    installed = (
-        _is_installed("wb-hdmi")
-        or _is_installed("wb-hdmi-wayland")
-    )
+    installed = _is_installed("wb-hdmi") or _is_installed("wb-hdmi-wayland")
 
     out: List[Dict[str, str]] = []
 

--- a/hdmi.py
+++ b/hdmi.py
@@ -300,32 +300,6 @@ def get_monitor_info() -> str:
     return "No monitor detected"
 
 
-def _cvt_modeline(res: str, refresh: str) -> str:
-    """Generate a VESA CVT Modeline for given resolution and refresh via `cvt`.
-
-    Args:
-        res: Resolution in the form "WxH" (e.g., "3840x2160").
-        refresh: Refresh rate string (e.g., "60.00").
-
-    Returns:
-        Modeline payload without the leading word "Modeline", or an empty string
-        when generation fails or `cvt` is not available.
-    """
-    try:
-        w, h = res.split("x")
-    except ValueError:
-        return ""
-    try:
-        out = subprocess.check_output(["cvt", w, h, refresh], text=True, stderr=subprocess.DEVNULL)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return ""
-    for line in out.splitlines():
-        line = line.strip()
-        if line.startswith("Modeline "):
-            return line[len("Modeline ") :]
-    return ""
-
-
 def _strip_name_from_modeline_payload(payload: str) -> str:
     """Remove the leading quoted mode name from a Modeline payload string."""
     if not payload:
@@ -394,29 +368,8 @@ def _make_edid_entry(name: str, info: Dict[str, object], e: Dict[str, object]) -
     }
 
 
-def _make_cvt_entry(name: str, info: Dict[str, object], tail: str) -> Dict[str, object]:
-    """Format one CVT entry."""
-    try:
-        cvt_khz = int(round(float(tail.split()[0]) * 1000))
-    except ValueError:
-        cvt_khz = 0
-    w = int(info["w"])
-    h = int(info["h"])
-    rr = float(info["r"])
-    return {
-        "kind": "cvt",
-        "value": f"{name}|CVT:{cvt_khz}",
-        "title": f"{name} (VESA CVT - {tail.split()[0]}MHz)",
-        "payload": f'"{name}" {tail}',
-        "name": name,
-        "w": w,
-        "h": h,
-        "r": rr,
-    }
-
-
 def _build_detailed_entries(modes: List[Dict[str, object]]) -> List[Dict[str, object]]:
-    """Build detailed EDID/CVT entries for modes with width >= 2560."""
+    """Build detailed EDID entries for modes with width >= 2560."""
     grouped: Dict[str, Dict[str, object]] = {}
     for m in modes:
         try:
@@ -440,14 +393,8 @@ def _build_detailed_entries(modes: List[Dict[str, object]]) -> List[Dict[str, ob
     detail: List[Dict[str, object]] = []
     for name, info in grouped.items():
         edids = sorted(info["edids"], key=lambda e: e["pclk_khz"])
-        edid_tails = set()
         for e in edids:
-            entry = _make_edid_entry(name, info, e)
-            detail.append(entry)
-            edid_tails.add(_strip_name_from_modeline_payload(e["payload"]))
-        cvt_tail = _strip_name_from_modeline_payload(_cvt_modeline(info["res"], info["refresh"]))
-        if cvt_tail and cvt_tail not in edid_tails:
-            detail.append(_make_cvt_entry(name, info, cvt_tail))
+            detail.append(_make_edid_entry(name, info, e))
     detail.sort(key=lambda e: (e["w"], e["h"], e["r"]), reverse=True)
     return detail
 
@@ -458,7 +405,7 @@ def _build_grouped_entries() -> List[Dict[str, object]]:
     Groups consist of:
       - one Auto entry (preferred EDID)
       - flat resolutions from modetest
-      - detailed EDID/CVT for resolutions >= 2560px width
+      - detailed EDID entries for resolutions >= 2560px width
     """
     entries: List[Dict[str, object]] = []
     modes = _parse_modetest_modes()
@@ -488,7 +435,7 @@ def _build_grouped_entries() -> List[Dict[str, object]]:
 
     entries.extend(_build_basic_entries(modes))
 
-    # Detailed EDID/CVT entries
+    # Detailed EDID entries
     entries.extend(_build_detailed_entries(modes))
 
     return entries
@@ -497,7 +444,7 @@ def _build_grouped_entries() -> List[Dict[str, object]]:
 def get_hdmi_modes() -> List[Dict[str, str]]:
     """Return modes for the Web UI combobox.
 
-    Includes flat modetest resolutions and detailed >2K EDID/CVT entries with
+    Includes flat modetest resolutions and detailed >2K EDID entries with
     unique values (value suffix encodes the timing source and pixel clock).
     May include the Auto entry depending on upstream grouping logic.
     """
@@ -543,7 +490,7 @@ def _apply_by_index(index_str: str) -> int:
     """Print a Modeline payload for the selected entry when available.
 
     0 selects the preferred EDID mode. Positive indices map to the printed list
-    order: flat resolutions first, then detailed EDID/CVT entries.
+    order: flat resolutions first, then detailed EDID entries.
     Returns a shell-like exit code (0 on success).
     """
     entries = _build_grouped_entries()
@@ -559,7 +506,7 @@ def _apply_by_index(index_str: str) -> int:
     # Flatten selection order: flat resolutions first, then detailed
     filtered: List[Dict[str, object]] = []
     filtered.extend([e for e in entries if e.get("kind") == "mode"])
-    filtered.extend([e for e in entries if e.get("kind") in {"edid", "cvt"}])
+    filtered.extend([e for e in entries if e.get("kind") == "edid"])
     if idx < 1 or idx > len(filtered):
         print("Index out of range", file=sys.stderr)
         return 2
@@ -567,7 +514,7 @@ def _apply_by_index(index_str: str) -> int:
     kind = str(e.get("kind"))
     if kind == "mode":
         return 0
-    # detailed edid/cvt
+    # detailed edid
     print(str(e["payload"]))
     return 0
 
@@ -588,9 +535,9 @@ def main() -> int:
             if e.get("kind") == "mode":
                 print(f"{i} - {e['title']}")
                 i += 1
-        # detailed EDID/CVT entries next
+        # detailed EDID entries next
         for e in entries:
-            if e.get("kind") in {"edid", "cvt"}:
+            if e.get("kind") == "edid":
                 print(f"{i} - {e['title']}")
                 i += 1
         return 0

--- a/hdmi.py
+++ b/hdmi.py
@@ -456,7 +456,10 @@ def get_hdmi_modes() -> List[Dict[str, str]]:
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
-    installed = _is_installed("wb-hdmi") or _is_installed("wb-hdmi-xorg")
+    installed = (
+        _is_installed("wb-hdmi")
+        or _is_installed("wb-hdmi-wayland")
+    )
 
     out: List[Dict[str, str]] = []
 
@@ -468,7 +471,7 @@ def get_hdmi_modes() -> List[Dict[str, str]]:
         # Expose a single message in case any UI watches available_hdmi_modes
         msg = (
             "To use the graphical interface, you need to install the "
-            "wb-hdmi or wb-hdmi-xorg package: apt install wb-hdmi"
+            "wb-hdmi or wb-hdmi-wayland package: apt install wb-hdmi"
         )
         out.append({"value": "auto", "title": msg})
 

--- a/hdmi.py
+++ b/hdmi.py
@@ -500,7 +500,10 @@ def get_hdmi_modes() -> List[Dict[str, str]]:
             out.append({"value": str(e["value"]), "title": str(e["title"])})
     else:
         # Expose a single message in case any UI watches available_hdmi_modes
-        msg = "To use the graphical interface, you need to install the wb-hdmi package: apt install wb-hdmi"
+        msg = (
+            "To use the graphical interface, you need to install the "
+            "wb-hdmi or wb-hdmi-xorg package: apt install wb-hdmi"
+        )
         out.append({"value": "auto", "title": msg})
 
     return out

--- a/hdmi.py
+++ b/hdmi.py
@@ -300,20 +300,9 @@ def get_monitor_info() -> str:
     return "No monitor detected"
 
 
-def _strip_name_from_modeline_payload(payload: str) -> str:
-    """Remove the leading quoted mode name from a Modeline payload string."""
-    if not payload:
-        return payload
-    parts = payload.split(" ", 1)
-    if len(parts) == 2 and parts[0].startswith('"'):
-        return parts[1]
-    return payload
-
-
 def _build_basic_entries(modes: List[Dict[str, object]]) -> List[Dict[str, object]]:
     """Build unique flat resolution entries from modetest data."""
     entries: List[Dict[str, object]] = []
-    seen = set()
 
     def res_key(res: str) -> Tuple[int, int]:
         try:
@@ -333,9 +322,6 @@ def _build_basic_entries(modes: List[Dict[str, object]]) -> List[Dict[str, objec
     )
 
     for res in unique_modes:
-        if res in seen:
-            continue
-        seen.add(res)
         entries.append(
             {
                 "kind": "mode",
@@ -550,4 +536,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # pragma: no cover

--- a/hdmi.py
+++ b/hdmi.py
@@ -114,7 +114,7 @@ def _parse_modetest_modes() -> List[Dict[str, object]]:
     return modes
 
 
-def _read_current_resolution() -> str:
+def _read_current_resolution() -> str:  # pylint: disable=too-many-branches
     """Return current active HDMI resolution from modetest CRTC state."""
     txt = _run_modetest_full()
     if not txt:

--- a/modules/wbe2-hdmi.sh
+++ b/modules/wbe2-hdmi.sh
@@ -3,7 +3,8 @@ source "$DATADIR/modules/utils.sh"
 
 XORG_CONFIG_PATH="/etc/X11/xorg.conf.d/10-monitor.conf"
 XINIT_SERVICE="xinit.service"
-SWAY_SERVICE="sway-kiosk.service"
+SWAY_PACKAGE="wb-sway-kiosk"
+SWAY_SERVICE="wb-sway-kiosk.service"
 
 _run_systemctl() {
 	systemctl "$@" >/dev/null 2>&1 || true
@@ -24,7 +25,7 @@ _use_legacy_xorg() {
 }
 
 _use_sway_runtime() {
-	_is_installed "wb-hdmi-wayland"
+	_is_installed "$SWAY_PACKAGE"
 }
 
 _config_mode_to_xorg() {

--- a/modules/wbe2-hdmi.sh
+++ b/modules/wbe2-hdmi.sh
@@ -20,11 +20,11 @@ _is_installed() {
 }
 
 _use_legacy_xorg() {
-	_is_installed "wb-hdmi-xorg"
+	_is_installed "wb-hdmi"
 }
 
 _use_sway_runtime() {
-	_is_installed "wb-hdmi"
+	_is_installed "wb-hdmi-wayland"
 }
 
 _config_mode_to_xorg() {

--- a/modules/wbe2-hdmi.sh
+++ b/modules/wbe2-hdmi.sh
@@ -1,135 +1,129 @@
 #!/bin/bash
 source "$DATADIR/modules/utils.sh"
 
+XORG_CONFIG_PATH="/etc/X11/xorg.conf.d/10-monitor.conf"
+XINIT_SERVICE="xinit.service"
+SWAY_SERVICE="sway-kiosk.service"
+WESTON_SERVICE="weston.service"
+LEGACY_KIOSK_SERVICE="wb-kiosk.service"
+WESTON_CONFIG_PATH="/etc/xdg/weston/weston.ini"
+
+_run_systemctl() {
+	systemctl "$@" >/dev/null 2>&1 || true
+}
+
+_run_systemctl_async() {
+	systemctl --no-block "$@" >/dev/null 2>&1 || true
+}
+
+_is_installed() {
+	local package=$1
+
+	dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"
+}
+
+_use_legacy_xorg() {
+	_is_installed "wb-hdmi-xorg"
+}
+
+_config_mode_to_xorg() {
+	local mode=$1
+	local base
+
+	if [[ -z "$mode" || "$mode" == "auto" || "$mode" == "null" ]]; then
+		return 0
+	fi
+
+	base="${mode%%|*}"
+	if [[ "$base" == *-* ]]; then
+		echo "${base%-*}"
+		return 0
+	fi
+
+	echo "$base"
+}
+
+_config_rotate_to_xorg() {
+	case "$1" in
+		90)
+			echo "right"
+			;;
+		180)
+			echo "inverted"
+			;;
+		270)
+			echo "left"
+			;;
+		*)
+			echo "normal"
+			;;
+	esac
+}
+
+_generate_xorg_config() {
+	local mode rotate xorg_mode xrotate
+
+	mode="$(config_module_option ".mode")"
+	rotate="$(config_module_option ".rotate")"
+
+	xorg_mode="$(_config_mode_to_xorg "$mode")"
+	xrotate="$(_config_rotate_to_xorg "$rotate")"
+
+	mkdir -p "$(dirname "$XORG_CONFIG_PATH")"
+
+	{
+		echo 'Section "Monitor"'
+		echo '    Identifier "HDMI-1"'
+		if [[ -n "$xorg_mode" ]]; then
+			echo "    Option \"PreferredMode\" \"$xorg_mode\""
+		fi
+		echo "    Option \"Rotate\" \"$xrotate\""
+		echo 'EndSection'
+	} > "$XORG_CONFIG_PATH"
+}
+
+_cleanup_runtime_artifacts() {
+	rm -f "$WESTON_CONFIG_PATH" "$XORG_CONFIG_PATH"
+}
+
+_restart_sway_stack() {
+	_run_systemctl stop "$XINIT_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+	_run_systemctl_async restart "$SWAY_SERVICE"
+}
+
+_restart_xorg_stack() {
+	_run_systemctl stop "$SWAY_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+	_run_systemctl_async restart "$XINIT_SERVICE"
+}
+
 hook_module_add() {
-    local XORG_CONFIG_PATH="/etc/X11/xorg.conf.d/10-monitor.conf"
-    local URL_CONFIG_PATH="/root/url"
+	if _use_legacy_xorg; then
+		rm -f "$WESTON_CONFIG_PATH"
+		_generate_xorg_config
+		return 0
+	fi
 
-    # Extract module options via jq
-    local mode="$(config_module_option ".mode")"
-    local rotate="$(config_module_option ".rotate")"
-    local url="$(config_module_option ".url")"
-
-    # Parse mode: may be "WxH-Rate|EDID" / "WxH-Rate|CVT" / "WxH-Rate" / "WxH"
-    local res=""
-    local rate=""
-    local variant=""
-    local modeline_name=""
-    local modeline_def=""
-    if [[ -n "$mode" && "$mode" != "auto" ]]; then
-        # Split variant suffix after '|', if present
-        if [[ "$mode" == *"|"* ]]; then
-            variant="${mode##*|}"
-            variant_base="${variant%%:*}"
-            variant_extra="${variant#*:}"
-            [[ "$variant" == "$variant_base" ]] && variant_extra=""
-            mode="${mode%%|*}"
-        fi
-        if [[ "$mode" == *-* ]]; then
-            res="${mode%%-*}"
-            rate="${mode##*-}"
-        else
-            res="$mode"
-        fi
-    fi
-
-    # Get Modeline via hdmi.py (EDID -> built-in CVT) and remember target index
-    if [[ -n "$res" && -n "$rate" ]]; then
-        local w="${res%x*}"
-        local h="${res#*x}"
-        # Find target mode index from hdmi.py list (one mode per line)
-        local idx
-        if [[ "$variant" == "CVT" ]]; then
-            # Match titles starting with "WxH-Rate (VESA CVT..."
-            idx=$( /usr/lib/wb-hwconf-manager/hdmi.py 2>/dev/null | awk -F ' - ' -v base="${w}x${h}-${rate}" 'index($2, base " (VESA CVT")==1 {print $1; exit}' )
-        elif [[ "$variant" == "EDID" ]]; then
-            # Match titles starting with "WxH-Rate (EDID ..."
-            idx=$( /usr/lib/wb-hwconf-manager/hdmi.py 2>/dev/null | awk -F ' - ' -v base="${w}x${h}-${rate}" 'index($2, base " (EDID ")==1 {print $1; exit}' )
-        else
-            # Generic: strip suffix " ( ... )" and match by base name
-            idx=$( /usr/lib/wb-hwconf-manager/hdmi.py 2>/dev/null | awk -F ' - ' -v target="${w}x${h}-${rate}" '{t=$2; sub(/ \(.+\)$/,"",t); if(t==target){print $1; exit}}' )
-        fi
-        # Generate modeline to write into Xorg config
-        if [[ -n "$idx" ]]; then
-            modeline_def=$(/usr/lib/wb-hwconf-manager/hdmi.py "$idx" 2>/dev/null)
-        fi
-
-        # Mode name is the first token (quoted) from modeline_def
-        if [[ -n "$modeline_def" ]]; then
-            modeline_name=$(sed -E 's/^"([^"]+)".*$/\1/' <<< "$modeline_def")
-            # Normalize mode name if needed
-            if [[ "$modeline_name" != "${w}x${h}-${rate}" ]]; then
-                local norm_name="${w}x${h}-${rate}"
-                modeline_def=$(sed -E "s/^\"[^\"]+\"/\"${norm_name}\"/" <<< "$modeline_def")
-                modeline_name="$norm_name"
-            fi
-        fi
-    fi
-
-    # Map rotate degrees to X11 value (normal, left, right, inverted)
-    case "$rotate" in
-        90) xrotate="right" ;;
-        180) xrotate="inverted" ;;
-        270) xrotate="left" ;;
-        *) xrotate="normal" ;;
-    esac
-
-    # Generate xorg.conf.d/10-monitor.conf
-    mkdir -p "$(dirname "$XORG_CONFIG_PATH")"
-    {
-        echo 'Section "Monitor"'
-        echo '    Identifier "HDMI-1"'
-        # If modeline is available — add it and set as preferred
-        if [[ -n "$modeline_def" && -n "$modeline_name" ]]; then
-            echo "    Modeline $modeline_def"
-            echo "    Option \"PreferredMode\" \"$modeline_name\""
-        elif [[ -n "$res" ]]; then
-            # Fallback: at least set desired resolution
-            echo "    Option \"PreferredMode\" \"$res\""
-        fi
-        echo "    Option \"Rotate\" \"$xrotate\""
-        echo 'EndSection'
-    } > "$XORG_CONFIG_PATH"
-
-    if [[ -n "$url" ]]; then
-        echo "$url" > "$URL_CONFIG_PATH"
-    else
-        rm "$URL_CONFIG_PATH"
-    fi
-
-    # Apply xrandr settings or start xinit
-    if pgrep -x xinit > /dev/null; then
-        echo "Xinit is running. Applying xrandr settings..."
-        export DISPLAY=:0.0
-
-        # If index found — apply mode by number (hdmi.py will add it if needed)
-        if [[ -n "$idx" ]]; then
-            /usr/lib/wb-hwconf-manager/hdmi.py "$idx" >/dev/null 2>&1 || true
-        else
-            # Fallback: use xrandr by resolution and rate
-            cmd=(xrandr --output HDMI-1)
-            if [[ -n "$res" ]]; then
-                cmd+=("--mode" "$res")
-                [[ -n "$rate" ]] && cmd+=("--rate" "$rate")
-            fi
-            "${cmd[@]}" || true
-        fi
-
-        # Rotate screen
-        xrandr --output HDMI-1 --rotate "$xrotate" || true
-
-    else
-        systemctl start xinit.service
-    fi
-
+	_cleanup_runtime_artifacts
 }
 
 hook_module_init() {
-	systemctl enable xinit.service
-	systemctl start xinit.service &
+	if _use_legacy_xorg; then
+		rm -f "$WESTON_CONFIG_PATH"
+		_generate_xorg_config
+		_run_systemctl disable "$SWAY_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+		_run_systemctl enable "$XINIT_SERVICE"
+		_restart_xorg_stack
+		return 0
+	fi
+
+	_cleanup_runtime_artifacts
+	_run_systemctl disable "$XINIT_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+	_run_systemctl enable "$SWAY_SERVICE"
+	_restart_sway_stack
 }
 
 hook_module_deinit() {
-	systemctl stop xinit.service &
-	systemctl disable xinit.service
+	_run_systemctl stop "$SWAY_SERVICE" "$LEGACY_KIOSK_SERVICE" "$WESTON_SERVICE" "$XINIT_SERVICE"
+	_run_systemctl disable "$SWAY_SERVICE" "$LEGACY_KIOSK_SERVICE" "$WESTON_SERVICE" "$XINIT_SERVICE"
+	_cleanup_runtime_artifacts
 }

--- a/modules/wbe2-hdmi.sh
+++ b/modules/wbe2-hdmi.sh
@@ -4,9 +4,6 @@ source "$DATADIR/modules/utils.sh"
 XORG_CONFIG_PATH="/etc/X11/xorg.conf.d/10-monitor.conf"
 XINIT_SERVICE="xinit.service"
 SWAY_SERVICE="sway-kiosk.service"
-WESTON_SERVICE="weston.service"
-LEGACY_KIOSK_SERVICE="wb-kiosk.service"
-WESTON_CONFIG_PATH="/etc/xdg/weston/weston.ini"
 
 _run_systemctl() {
 	systemctl "$@" >/dev/null 2>&1 || true
@@ -24,6 +21,10 @@ _is_installed() {
 
 _use_legacy_xorg() {
 	_is_installed "wb-hdmi-xorg"
+}
+
+_use_sway_runtime() {
+	_is_installed "wb-hdmi"
 }
 
 _config_mode_to_xorg() {
@@ -83,22 +84,21 @@ _generate_xorg_config() {
 }
 
 _cleanup_runtime_artifacts() {
-	rm -f "$WESTON_CONFIG_PATH" "$XORG_CONFIG_PATH"
+	rm -f "$XORG_CONFIG_PATH"
 }
 
 _restart_sway_stack() {
-	_run_systemctl stop "$XINIT_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+	_run_systemctl stop "$XINIT_SERVICE"
 	_run_systemctl_async restart "$SWAY_SERVICE"
 }
 
 _restart_xorg_stack() {
-	_run_systemctl stop "$SWAY_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+	_run_systemctl stop "$SWAY_SERVICE"
 	_run_systemctl_async restart "$XINIT_SERVICE"
 }
 
 hook_module_add() {
 	if _use_legacy_xorg; then
-		rm -f "$WESTON_CONFIG_PATH"
 		_generate_xorg_config
 		return 0
 	fi
@@ -108,22 +108,28 @@ hook_module_add() {
 
 hook_module_init() {
 	if _use_legacy_xorg; then
-		rm -f "$WESTON_CONFIG_PATH"
 		_generate_xorg_config
-		_run_systemctl disable "$SWAY_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+		_run_systemctl disable "$SWAY_SERVICE"
 		_run_systemctl enable "$XINIT_SERVICE"
 		_restart_xorg_stack
 		return 0
 	fi
 
+	if ! _use_sway_runtime; then
+		_run_systemctl stop "$SWAY_SERVICE" "$XINIT_SERVICE"
+		_run_systemctl disable "$SWAY_SERVICE" "$XINIT_SERVICE"
+		_cleanup_runtime_artifacts
+		return 0
+	fi
+
 	_cleanup_runtime_artifacts
-	_run_systemctl disable "$XINIT_SERVICE" "$WESTON_SERVICE" "$LEGACY_KIOSK_SERVICE"
+	_run_systemctl disable "$XINIT_SERVICE"
 	_run_systemctl enable "$SWAY_SERVICE"
 	_restart_sway_stack
 }
 
 hook_module_deinit() {
-	_run_systemctl stop "$SWAY_SERVICE" "$LEGACY_KIOSK_SERVICE" "$WESTON_SERVICE" "$XINIT_SERVICE"
-	_run_systemctl disable "$SWAY_SERVICE" "$LEGACY_KIOSK_SERVICE" "$WESTON_SERVICE" "$XINIT_SERVICE"
+	_run_systemctl stop "$SWAY_SERVICE" "$XINIT_SERVICE"
+	_run_systemctl disable "$SWAY_SERVICE" "$XINIT_SERVICE"
 	_cleanup_runtime_artifacts
 }

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -1,8 +1,9 @@
+import io
 import json
 from pathlib import Path
 
 import config as config_module
-from config import from_confed, make_modules_list, to_confed
+from config import from_confed, make_modules_list, to_combined_config, to_confed
 
 MODULES_DIR = "./test/config/modules"
 OLD_CONFIG_PATH = "./test/config/old_config.conf"
@@ -58,6 +59,96 @@ def test_make_vendor_modules_list():
     with open(VENDOR_CONFED_JSON_PATH, "r", encoding="utf-8") as config_file:
         confed_json = json.load(config_file)
     assert confed_json["modules"] == make_modules_list(MODULES_DIR, VENDOR_CONFIG_PATH)
+
+
+def test_get_compatible_boards_list(monkeypatch, tmp_path):
+    device_tree = tmp_path / "device-tree"
+    device_tree.mkdir()
+    (device_tree / "compatible").write_text("wirenboard,wirenboard-85x\x00other-board\x00", encoding="utf-8")
+
+    monkeypatch.setattr(config_module.os, "readlink", lambda path: str(device_tree))
+
+    assert config_module.get_compatible_boards_list() == [
+        "wirenboard,wirenboard-85x",
+        "other-board",
+        "",
+    ]
+
+
+def test_get_board_config_path(monkeypatch):
+    monkeypatch.setattr(config_module, "get_compatible_boards_list", lambda: ["wirenboard,wirenboard-85x"])
+    assert config_module.get_board_config_path().endswith("/boards/wb85x.conf")
+
+    monkeypatch.setattr(config_module, "get_compatible_boards_list", lambda: ["unknown-board"])
+    assert config_module.get_board_config_path().endswith("/boards/default.conf")
+
+
+def test_extract_config_skips_slots_without_slot_id():
+    combined_config = {"slots": [{"id": "slot-without-id", "module": "wbe2-ao-10v-2", "options": {}}]}
+    board_slots = {
+        "slots": [
+            {
+                "id": "slot-without-id",
+                "compatible": ["wbe2"],
+                "module": "",
+                "options": {},
+            }
+        ]
+    }
+
+    assert not config_module.extract_config(combined_config, board_slots, [])
+
+
+def test_to_combined_config():
+    result = to_combined_config(
+        json.dumps({"mod1": {"module": "wbe2-ao-10v-2", "options": {}}}),
+        BOARD_CONF_PATH,
+        MODULES_DIR,
+        "",
+    )
+
+    slot = next(slot for slot in result["slots"] if slot["id"] == "wb72-mod1")
+    assert slot["module"] == "wbe2-ao-10v-2"
+
+
+def test_main_to_confed(monkeypatch, capsys):
+    monkeypatch.setattr(config_module.sys, "argv", ["config.py", "--to-confed"])
+    monkeypatch.setattr(config_module, "get_board_config_path", lambda: BOARD_CONF_PATH)
+    monkeypatch.setattr(config_module, "to_confed", lambda *args: {"ok": True})
+
+    config_module.main()
+
+    assert json.loads(capsys.readouterr().out) == {"ok": True}
+
+
+def test_main_from_confed(monkeypatch, capsys):
+    monkeypatch.setattr(config_module.sys, "argv", ["config.py", "--from-confed"])
+    monkeypatch.setattr(config_module.sys, "stdin", io.StringIO("{}"))
+    monkeypatch.setattr(config_module, "get_board_config_path", lambda: BOARD_CONF_PATH)
+    monkeypatch.setattr(config_module, "from_confed", lambda *args: {"ok": True})
+
+    config_module.main()
+
+    assert json.loads(capsys.readouterr().out) == {"ok": True}
+
+
+def test_main_to_combined_config(monkeypatch, capsys):
+    monkeypatch.setattr(config_module.sys, "argv", ["config.py", "--to-combined-config"])
+    monkeypatch.setattr(config_module.sys, "stdin", io.StringIO("{}"))
+    monkeypatch.setattr(config_module, "get_board_config_path", lambda: BOARD_CONF_PATH)
+    monkeypatch.setattr(config_module, "to_combined_config", lambda *args: {"ok": True})
+
+    config_module.main()
+
+    assert json.loads(capsys.readouterr().out) == {"ok": True}
+
+
+def test_main_prints_usage(monkeypatch, capsys):
+    monkeypatch.setattr(config_module.sys, "argv", ["config.py"])
+
+    config_module.main()
+
+    assert "usage:" in capsys.readouterr().out
 
 
 def test_to_confed_adds_monitor_info(monkeypatch, tmp_path):

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -43,6 +43,77 @@ def test_build_basic_entries_from_modetest(monkeypatch):
     assert [entry["value"] for entry in out] == ["3840x2160", "2560x1440"]
 
 
+def test_run_modetest_success(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    calls = []
+
+    def fake_check_output(args, text=False):  # pylint: disable=unused-argument
+        calls.append((args, text))
+        return "modetest output"
+
+    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
+
+    assert hdmi._run_modetest() == "modetest output"  # pylint: disable=protected-access
+    assert calls == [(["modetest", "-M", "sun4i-drm", "-c"], True)]
+
+
+def test_run_modetest_failure(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+
+    def fake_check_output(*_args, **_kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
+
+    assert hdmi._run_modetest() == ""  # pylint: disable=protected-access
+
+
+def test_parse_mode_line_rejects_invalid_line():
+    hdmi = importlib.import_module("hdmi")
+    assert hdmi._parse_mode_line("not a mode line") is None  # pylint: disable=protected-access
+
+
+def test_parse_modetest_modes_no_output(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    monkeypatch.setattr(hdmi, "_run_modetest", lambda: "")  # pylint: disable=protected-access
+
+    assert hdmi._parse_modetest_modes() == []  # pylint: disable=protected-access
+
+
+def test_parse_modetest_modes_stops_on_blank_line(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    sample = """
+Connectors:
+id encoder status name size (mm) modes encoders
+30 25 connected HDMI-A-1 160x90 4 25
+modes:
+index name refresh (Hz) hdisp hss hse htot vdisp vss vse vtot)
+
+#0 1920x1080 60.00 1920 2008 2052 2200 1080 1084 1089 1125 148500 flags: phsync, pvsync; type: driver
+""".strip(
+        "\n"
+    )
+    monkeypatch.setattr(hdmi, "_run_modetest", lambda: sample)  # pylint: disable=protected-access
+
+    assert hdmi._parse_modetest_modes() == []  # pylint: disable=protected-access
+
+
+def test_parse_modetest_modes_stops_on_non_mode_line(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    sample = """
+Connectors:
+id encoder status name size (mm) modes encoders
+30 25 connected HDMI-A-1 160x90 4 25
+modes:
+index name refresh (Hz) hdisp hss hse htot vdisp vss vse vtot)
+properties:
+#0 1920x1080 60.00 1920 2008 2052 2200 1080 1084 1089 1125 148500 flags: phsync, pvsync; type: driver
+""".strip()
+    monkeypatch.setattr(hdmi, "_run_modetest", lambda: sample)  # pylint: disable=protected-access
+
+    assert hdmi._parse_modetest_modes() == []  # pylint: disable=protected-access
+
+
 def test_main_listing_format(monkeypatch, capsys):
     """Lists simplified CLI output: '0 - auto' and flat entries without headers."""
     entries: List[dict] = [
@@ -171,7 +242,7 @@ def test_get_hdmi_modes_wayland_package_installed(monkeypatch):
             raise hdmi.subprocess.CalledProcessError(returncode=1, cmd=args)
         if package == "wb-hdmi-wayland":
             return "install ok installed\n"
-        raise AssertionError("unexpected package query")
+        raise AssertionError("unexpected package query")  # pragma: no cover
 
     entries: List[dict] = [
         {"kind": "auto", "value": "auto", "title": "Auto from EDID"},
@@ -281,6 +352,20 @@ def test_build_grouped_entries_aggregates(monkeypatch):
     assert {e["name"] for e in det} == {"3840x2160-60.00", "2560x1440-59.95"}
 
 
+def test_build_basic_entries_handles_invalid_resolution():
+    hdmi = importlib.import_module("hdmi")
+    entries = hdmi._build_basic_entries(  # pylint: disable=protected-access
+        [{"res": "badxvalue"}, {"res": "1280x720"}]
+    )
+
+    assert [entry["value"] for entry in entries] == ["1280x720", "badxvalue"]
+
+
+def test_build_detailed_entries_skips_invalid_resolution():
+    hdmi = importlib.import_module("hdmi")
+    assert hdmi._build_detailed_entries([{"res": "badxvalue"}]) == []  # pylint: disable=protected-access
+
+
 def test_build_grouped_entries_no_tools(monkeypatch):
     """With no modetest, returns only the Auto entry with empty payload."""
     hdmi = importlib.import_module("hdmi")
@@ -330,7 +415,7 @@ def test_find_connected_hdmi_edid(monkeypatch):
             return FakeFile("disconnected\n")
         if path.endswith("card1-HDMI-A-1/status"):
             return FakeFile("connected\n")
-        raise AssertionError(f"unexpected open path: {path}")
+        raise AssertionError(f"unexpected open path: {path}")  # pragma: no cover
 
     monkeypatch.setattr(hdmi, "open", fake_open, raising=False)
     monkeypatch.setattr(hdmi.os.path, "exists", lambda path: path.endswith("card1-HDMI-A-1/edid"))
@@ -338,6 +423,39 @@ def test_find_connected_hdmi_edid(monkeypatch):
     find_connected_hdmi_edid = getattr(hdmi, "_find_connected_hdmi_edid")
 
     assert find_connected_hdmi_edid() == "/sys/class/drm/card1-HDMI-A-1/edid"
+
+
+def test_find_connected_hdmi_edid_handles_errors_and_missing_edid(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+
+    monkeypatch.setattr(
+        hdmi.glob,
+        "glob",
+        lambda pattern: [
+            "/sys/class/drm/card0-HDMI-A-1/status",
+            "/sys/class/drm/card1-HDMI-A-1/status",
+        ],
+    )
+
+    def fake_open(path, mode="r", encoding=None):  # pylint: disable=unused-argument
+        class FakeFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return "connected\n"
+
+        if path.endswith("card0-HDMI-A-1/status"):
+            raise OSError
+        return FakeFile()
+
+    monkeypatch.setattr(hdmi, "open", fake_open, raising=False)
+    monkeypatch.setattr(hdmi.os.path, "exists", lambda path: False)
+
+    assert hdmi._find_connected_hdmi_edid() == ""  # pylint: disable=protected-access
 
 
 def test_read_monitor_name_uses_connected_hdmi(monkeypatch):
@@ -368,6 +486,17 @@ Model: '1234'
 
     name = hdmi._read_monitor_name("/tmp/edid")  # pylint: disable=protected-access
     assert name == "Preferred Name"
+
+
+def test_read_monitor_name_uses_monitor_name(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    edid_output = "Monitor name: 'Legacy Name'"
+
+    monkeypatch.setattr(hdmi.os.path, "exists", lambda path: True)
+    monkeypatch.setattr(hdmi.subprocess, "check_output", lambda *a, **k: edid_output)
+
+    name = hdmi._read_monitor_name("/tmp/edid")  # pylint: disable=protected-access
+    assert name == "Legacy Name"
 
 
 def test_read_monitor_name_fallback_to_vendor(monkeypatch):
@@ -415,6 +544,17 @@ def test_get_monitor_info_no_monitor(monkeypatch):
     assert info == "No monitor detected"
 
 
+def test_get_monitor_info_name_without_details(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    monkeypatch.setattr(hdmi, "_parse_modetest_modes", lambda: [])  # pylint: disable=protected-access
+    monkeypatch.setattr(hdmi, "_read_current_resolution", lambda: "")  # pylint: disable=protected-access
+    monkeypatch.setattr(
+        hdmi, "_read_monitor_name", lambda _p=None: "Panel"
+    )  # pylint: disable=protected-access
+
+    assert hdmi.get_monitor_info() == "Panel"
+
+
 def test_read_current_resolution(monkeypatch):
     hdmi = importlib.import_module("hdmi")
     monkeypatch.setattr(
@@ -422,6 +562,31 @@ def test_read_current_resolution(monkeypatch):
     )  # pylint: disable=protected-access
 
     assert hdmi._read_current_resolution() == "1280x720"  # pylint: disable=protected-access
+
+
+def test_parse_crtc_resolution_handles_disabled_crtc():
+    hdmi = importlib.import_module("hdmi")
+    assert hdmi._parse_crtc_resolution("51 55 (0,0) (0x0)", "51") == ""  # pylint: disable=protected-access
+
+
+def test_read_current_resolution_no_matching_crtc(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    sample = """
+Encoders:
+id crtc type possible crtcs possible clones
+25 51 TMDS 0x00000001 0x00000001
+
+Connectors:
+id encoder status name size (mm) modes encoders
+30 25 connected HDMI-A-1 160x90 4 25
+
+CRTCs:
+id fb pos size
+52 55 (0,0) (1280x720)
+""".strip()
+    monkeypatch.setattr(hdmi, "_run_modetest_full", lambda: sample)  # pylint: disable=protected-access
+
+    assert hdmi._read_current_resolution() == ""  # pylint: disable=protected-access
 
 
 def test_read_monitor_name_missing_file(monkeypatch):
@@ -446,3 +611,39 @@ def test_max_resolution_handles_invalid_entries():
     hdmi = importlib.import_module("hdmi")
     modes = [{"res": "bad"}, {"res": "640xa"}, {}]
     assert hdmi._max_resolution_from_modes(modes) == ""  # pylint: disable=protected-access
+
+
+def test_apply_by_index_invalid_value(monkeypatch, capsys):
+    hdmi = importlib.import_module("hdmi")
+    monkeypatch.setattr(hdmi, "_build_grouped_entries", lambda: [])  # pylint: disable=protected-access
+
+    assert hdmi._apply_by_index("bad") == 2  # pylint: disable=protected-access
+    assert "Invalid index" in capsys.readouterr().err
+
+
+def test_apply_by_index_out_of_range(monkeypatch, capsys):
+    hdmi = importlib.import_module("hdmi")
+    monkeypatch.setattr(
+        hdmi,
+        "_build_grouped_entries",
+        lambda: [{"kind": "auto", "title": "Auto", "payload": ""}],
+    )  # pylint: disable=protected-access
+
+    assert hdmi._apply_by_index("1") == 2  # pylint: disable=protected-access
+    assert "Index out of range" in capsys.readouterr().err
+
+
+def test_main_apply_numeric_arg(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    monkeypatch.setattr(sys, "argv", ["hdmi.py", "2"])  # nosec: B104 test adjusts argv
+    monkeypatch.setattr(hdmi, "_apply_by_index", lambda index: 7)  # pylint: disable=protected-access
+
+    assert hdmi.main() == 7
+
+
+def test_main_invalid_usage(monkeypatch, capsys):
+    hdmi = importlib.import_module("hdmi")
+    monkeypatch.setattr(sys, "argv", ["hdmi.py", "bad"])  # nosec: B104 test adjusts argv
+
+    assert hdmi.main() == 2
+    assert "Usage:" in capsys.readouterr().err

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -128,7 +128,7 @@ def test_get_hdmi_modes_not_installed(monkeypatch):
     assert isinstance(out, list) and len(out) == 1
     assert out[0]["value"] == "auto"
     assert "wb-hdmi" in out[0]["title"]
-    assert "wb-hdmi-xorg" in out[0]["title"]
+    assert "wb-hdmi-wayland" in out[0]["title"]
 
 
 def test_get_hdmi_modes_installed(monkeypatch):
@@ -161,15 +161,15 @@ def test_get_hdmi_modes_installed(monkeypatch):
     assert "1920x1080-60.00|EDID:148500" in values
 
 
-def test_get_hdmi_modes_legacy_package_installed(monkeypatch):
-    """wb-hdmi-xorg should also enable HDMI mode discovery for the UI."""
+def test_get_hdmi_modes_wayland_package_installed(monkeypatch):
+    """wb-hdmi-wayland should enable HDMI mode discovery for the UI."""
     hdmi = importlib.import_module("hdmi")
 
     def fake_check_output(args, text=False):  # pylint: disable=unused-argument
         package = args[-1]
         if package == "wb-hdmi":
             raise hdmi.subprocess.CalledProcessError(returncode=1, cmd=args)
-        if package == "wb-hdmi-xorg":
+        if package == "wb-hdmi-wayland":
             return "install ok installed\n"
         raise AssertionError("unexpected package query")
 

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -55,12 +55,6 @@ def test_main_listing_format(monkeypatch, capsys):
             "name": "3840x2160-60.00",
             "payload": '"3840x2160-60.00" 594 3840 4016 4104 4400 2160 2168 2178 2250 +hsync +vsync',
         },
-        {
-            "kind": "cvt",
-            "title": "3840x2160-60.00 (VESA CVT - 712.75MHz)",
-            "name": "3840x2160-60.00",
-            "payload": '"3840x2160-60.00" 712.75 3840 4016 4104 4400 2160 2168 2178 2250 +hsync +vsync',
-        },
     ]
 
     hdmi = importlib.import_module("hdmi")
@@ -77,7 +71,7 @@ def test_main_listing_format(monkeypatch, capsys):
     assert not any(line.startswith("2)") or line.startswith("3)") for line in out)
     # Next lines are a flat sequence of titles from entries
     assert any("1920x1080" in line for line in out)
-    assert any(("3840x2160-60.00 (EDID" in line) or ("VESA CVT" in line) for line in out)
+    assert any("3840x2160-60.00 (EDID" in line for line in out)
 
 
 def test_apply_by_index_flat_mode(monkeypatch, capsys):
@@ -153,11 +147,6 @@ def test_get_hdmi_modes_installed(monkeypatch):
             "value": "1920x1080-60.00|EDID:148500",
             "title": "1920x1080-60.00 (EDID - 148.50MHz)",
         },
-        {
-            "kind": "cvt",
-            "value": "1920x1080-60.00|CVT:173000",
-            "title": "1920x1080-60.00 (VESA CVT - 173.00MHz)",
-        },
     ]
 
     monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
@@ -170,7 +159,6 @@ def test_get_hdmi_modes_installed(monkeypatch):
     # Includes flat modes and detailed entries
     assert "1920x1080" in values
     assert "1920x1080-60.00|EDID:148500" in values
-    assert "1920x1080-60.00|CVT:173000" in values
 
 
 def test_get_hdmi_modes_legacy_package_installed(monkeypatch):
@@ -196,34 +184,6 @@ def test_get_hdmi_modes_legacy_package_installed(monkeypatch):
     assert out == [{"value": "auto", "title": "Auto from EDID"}]
 
 
-def test_cvt_modeline_parsing(monkeypatch):
-    """Parses cvt output and returns the Modeline payload (without the word 'Modeline')."""
-    hdmi = importlib.import_module("hdmi")
-
-    def fake_check_output(args, text=False, stderr=None):  # pylint: disable=unused-argument
-        if args and args[0] == "cvt":
-            return 'Modeline "3840x2160_60.00" 533.25 3840 4016 4104 4400 2160 2168 2178 2250 +hsync +vsync\n'
-        raise AssertionError("unexpected command")
-
-    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
-    payload = hdmi._cvt_modeline("3840x2160", "60.00")  # pylint: disable=protected-access
-    assert payload.startswith('"3840x2160_60.00" 533.25')
-
-
-def test_cvt_modeline_no_cvt(monkeypatch):
-    """Returns empty payload when the 'cvt' tool is missing or fails."""
-    hdmi = importlib.import_module("hdmi")
-
-    def fake_check_output(args, text=False, stderr=None):  # pylint: disable=unused-argument
-        if args and args[0] == "cvt":
-            raise FileNotFoundError
-        return ""
-
-    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
-    payload = hdmi._cvt_modeline("3840x2160", "60.00")  # pylint: disable=protected-access
-    assert payload == ""
-
-
 def test_apply_by_index_auto(monkeypatch, capsys):
     """Index 0 prints the Auto Modeline payload."""
     hdmi = importlib.import_module("hdmi")
@@ -243,7 +203,7 @@ def test_apply_by_index_auto(monkeypatch, capsys):
 
 
 def test_build_grouped_entries_aggregates(monkeypatch):
-    """Aggregates Auto, flat modetest resolutions, and detailed EDID/CVT entries."""
+    """Aggregates Auto, flat modetest resolutions, and detailed EDID entries."""
     hdmi = importlib.import_module("hdmi")
 
     # Provide modetest modes: include >=2.5K widths and one below threshold
@@ -301,12 +261,6 @@ def test_build_grouped_entries_aggregates(monkeypatch):
     monkeypatch.setattr(
         hdmi, "_parse_modetest_modes", lambda: modetest_modes
     )  # pylint: disable=protected-access
-    # Ensure CVT is unique so it is added
-    monkeypatch.setattr(
-        hdmi,
-        "_cvt_modeline",
-        lambda res, r: f'"{res}-{r}" 700.00 10 20 30 40 50 60 70 80 +hsync +vsync',  # pylint: disable=protected-access
-    )
 
     entries = hdmi._build_grouped_entries()  # pylint: disable=protected-access
     assert entries, "Expected non-empty entries"
@@ -319,17 +273,12 @@ def test_build_grouped_entries_aggregates(monkeypatch):
     basic_values = {e["value"] for e in basic}
     assert {"3840x2160", "2560x1440", "1920x1080"}.issubset(basic_values)
 
-    # Detailed entries include EDID and CVT for >=2560 widths
-    det = [e for e in entries if e.get("kind") in {"edid", "cvt"}]
+    # Detailed entries include EDID for >=2560 widths
+    det = [e for e in entries if e.get("kind") == "edid"]
     names = {e["name"] for e in det}
     assert "3840x2160-60.00" in names
     assert "2560x1440-59.95" in names
-    kinds_per_name = {}
-    for e in det:
-        kinds_per_name.setdefault(e["name"], set()).add(e["kind"])
-    # Each name should have at least EDID, and CVT added due to unique tail
-    assert "edid" in kinds_per_name["3840x2160-60.00"] and "cvt" in kinds_per_name["3840x2160-60.00"]
-    assert "edid" in kinds_per_name["2560x1440-59.95"] and "cvt" in kinds_per_name["2560x1440-59.95"]
+    assert {e["name"] for e in det} == {"3840x2160-60.00", "2560x1440-59.95"}
 
 
 def test_build_grouped_entries_no_tools(monkeypatch):

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -199,7 +199,7 @@ def test_get_hdmi_modes_not_installed(monkeypatch):
     assert isinstance(out, list) and len(out) == 1
     assert out[0]["value"] == "auto"
     assert "wb-hdmi" in out[0]["title"]
-    assert "wb-hdmi-wayland" in out[0]["title"]
+    assert "wb-sway-kiosk" in out[0]["title"]
 
 
 def test_get_hdmi_modes_installed(monkeypatch):
@@ -232,15 +232,15 @@ def test_get_hdmi_modes_installed(monkeypatch):
     assert "1920x1080-60.00|EDID:148500" in values
 
 
-def test_get_hdmi_modes_wayland_package_installed(monkeypatch):
-    """wb-hdmi-wayland should enable HDMI mode discovery for the UI."""
+def test_get_hdmi_modes_sway_kiosk_package_installed(monkeypatch):
+    """wb-sway-kiosk should enable HDMI mode discovery for the UI."""
     hdmi = importlib.import_module("hdmi")
 
     def fake_check_output(args, text=False):  # pylint: disable=unused-argument
         package = args[-1]
         if package == "wb-hdmi":
             raise hdmi.subprocess.CalledProcessError(returncode=1, cmd=args)
-        if package == "wb-hdmi-wayland":
+        if package == "wb-sway-kiosk":
             return "install ok installed\n"
         raise AssertionError("unexpected package query")  # pragma: no cover
 

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -2,13 +2,6 @@ import importlib
 import sys
 from typing import List
 
-XRANDR_SAMPLE = """
-HDMI-1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 160mm x 90mm
-   3840x2160     60.00*+ 50.00 30.00
-   2560x1440     59.95
-DP-1 disconnected (normal left inverted right x axis y axis)
-""".strip()
-
 
 MODETEST_SAMPLE = """
 Connectors:
@@ -21,48 +14,41 @@ index name refresh (Hz) hdisp hss hse htot vdisp vss vse vtot)
 #2 2560x1440 59.95 2560 2728 2792 3560 1440 1481 1488 1500  241500 flags: phsync, pvsync; type: dmt
 """.strip()
 
+MODETEST_WITH_CRTC_SAMPLE = """
+Encoders:
+id	crtc	type	possible crtcs	possible clones
+25	51	TMDS	0x00000001	0x00000001
 
-def test_parse_xrandr_modes_basic(monkeypatch):
-    """Parses xrandr --query output into a resolution->rates mapping."""
+Connectors:
+id	encoder	status		name		size (mm)	modes	encoders
+30	25	connected	HDMI-A-1	160x90		4	25
+modes:
+index name refresh (Hz) hdisp hss hse htot vdisp vss vse vtot)
+#0 1920x1080 60.00 1920 2008 2052 2200 1080 1084 1089 1125  148500 flags: phsync, pvsync; type: driver
+#1 1280x720 60.00 1280 1390 1430 1650 720 725 730 750  74250 flags: phsync, pvsync; type: preferred, driver
 
-    def fake_check_output(args, text=False, stderr=None):  # pylint: disable=unused-argument
-        if args[:2] == ["xrandr", "--query"]:
-            return XRANDR_SAMPLE
-        raise FileNotFoundError
+CRTCs:
+id	fb	pos	size
+51	55	(0,0)	(1280x720)
+""".strip()
 
-    monkeypatch.setenv("DISPLAY", ":0.0")
+def test_build_basic_entries_from_modetest(monkeypatch):
+    """Builds flat unique resolutions from modetest data."""
     hdmi = importlib.import_module("hdmi")
-    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
-
-    out = hdmi._parse_xrandr_modes("HDMI-1")  # pylint: disable=protected-access
-    assert out == {"3840x2160": ["60.00", "50.00", "30.00"], "2560x1440": ["59.95"]}
-
-
-def test_parse_xrandr_modes_fallback_to_modetest(monkeypatch):
-    """Falls back to EDID-derived resolutions when xrandr is unavailable."""
-
-    def fake_check_output(args, text=False, stderr=None):  # pylint: disable=unused-argument
-        if args[:2] == ["xrandr", "--query"]:
-            raise FileNotFoundError
-        return ""
-
-    hdmi = importlib.import_module("hdmi")
-    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
     monkeypatch.setattr(hdmi, "_run_modetest", lambda: MODETEST_SAMPLE)  # pylint: disable=protected-access
 
-    out = hdmi._parse_xrandr_modes("HDMI-1")  # pylint: disable=protected-access
-    # Fallback returns unique resolutions with empty rate lists
-    assert set(out.keys()) == {"3840x2160", "2560x1440"}
-    for v in out.values():
-        assert isinstance(v, list)
+    modes = hdmi._parse_modetest_modes()  # pylint: disable=protected-access
+    out = hdmi._build_basic_entries(modes)  # pylint: disable=protected-access
+
+    assert [entry["value"] for entry in out] == ["3840x2160", "2560x1440"]
 
 
 def test_main_listing_format(monkeypatch, capsys):
     """Lists simplified CLI output: '0 - auto' and flat entries without headers."""
     entries: List[dict] = [
         {"kind": "auto", "title": "Auto from EDID", "payload": ""},
-        {"kind": "xrandr", "title": "1920x1080", "name": "1920x1080", "payload": ""},
-        {"kind": "xrandr", "title": "3840x2160", "name": "3840x2160", "payload": ""},
+        {"kind": "mode", "title": "1920x1080", "name": "1920x1080", "payload": ""},
+        {"kind": "mode", "title": "3840x2160", "name": "3840x2160", "payload": ""},
         {
             "kind": "edid",
             "title": "3840x2160-60.00 (EDID - 594MHz)",
@@ -94,12 +80,11 @@ def test_main_listing_format(monkeypatch, capsys):
     assert any(("3840x2160-60.00 (EDID" in line) or ("VESA CVT" in line) for line in out)
 
 
-def test_apply_by_index_xrandr(monkeypatch):
-    """Applies an xrandr mode by index via 'xrandr --mode WxH'."""
-    # Build entries: one xrandr and one detailed
+def test_apply_by_index_flat_mode(monkeypatch, capsys):
+    """Flat mode entries are list-only and do not print a Modeline."""
     entries = [
         {"kind": "auto", "title": "Auto from EDID", "payload": ""},
-        {"kind": "xrandr", "title": "1920x1080", "name": "1920x1080", "payload": ""},
+        {"kind": "mode", "title": "1920x1080", "name": "1920x1080", "payload": ""},
         {
             "kind": "edid",
             "title": "1920x1080-60.00 (EDID - 148.50MHz)",
@@ -107,29 +92,19 @@ def test_apply_by_index_xrandr(monkeypatch):
             "payload": '"1920x1080-60.00" 148.50 1920 2008 2052 2200 1080 1084 1089 1125 +hsync +vsync',
         },
     ]
-    calls = []
-
-    def fake_run(args, check=False, stdout=None, stderr=None):  # pylint: disable=unused-argument
-        calls.append(args)
-
     hdmi = importlib.import_module("hdmi")
     monkeypatch.setattr(hdmi, "_build_grouped_entries", lambda: entries)  # pylint: disable=protected-access
-    monkeypatch.setattr(hdmi.subprocess, "run", fake_run)
 
     rc = hdmi._apply_by_index("1")  # pylint: disable=protected-access
     assert rc == 0
-    # Should invoke xrandr --mode for the resolution
-    assert any(
-        cmd[:3] == ["xrandr", "--output", "HDMI-1"] and cmd[3:5] == ["--mode", "1920x1080"] for cmd in calls
-    )
+    assert capsys.readouterr().out == ""
 
 
 def test_apply_by_index_detailed(monkeypatch):
-    """Ensures detailed EDID mode presence and applies it by quoted name."""
-    # Build entries: one xrandr and one detailed
+    """Detailed EDID mode prints its Modeline payload."""
     entries = [
         {"kind": "auto", "title": "Auto from EDID", "payload": ""},
-        {"kind": "xrandr", "title": "1920x1080", "name": "1920x1080", "payload": ""},
+        {"kind": "mode", "title": "1920x1080", "name": "1920x1080", "payload": ""},
         {
             "kind": "edid",
             "title": "1920x1080-60.00 (EDID - 148.50MHz)",
@@ -137,29 +112,12 @@ def test_apply_by_index_detailed(monkeypatch):
             "payload": '"1920x1080-60.00" 148.50 1920 2008 2052 2200 1080 1084 1089 1125 +hsync +vsync',
         },
     ]
-
-    added = {"ensure": []}
-    calls = []
-
-    def fake_run(args, check=False, stdout=None, stderr=None):  # pylint: disable=unused-argument
-        calls.append(args)
-
-    def fake_ensure(output, mode_name, payload):
-        added["ensure"].append((output, mode_name, payload))
-
     hdmi = importlib.import_module("hdmi")
     monkeypatch.setattr(hdmi, "_build_grouped_entries", lambda: entries)  # pylint: disable=protected-access
-    monkeypatch.setattr(hdmi, "_ensure_mode_present", fake_ensure)
-    monkeypatch.setattr(hdmi.subprocess, "run", fake_run)
 
     rc = hdmi._apply_by_index("2")  # pylint: disable=protected-access
     assert rc == 0
-    # Ensure mode was prepared and xrandr invoked by name
-    assert added["ensure"] and added["ensure"][0][1] == "1920x1080-60.00"
-    assert any(
-        cmd[:3] == ["xrandr", "--output", "HDMI-1"] and cmd[3:5] == ["--mode", "1920x1080-60.00"]
-        for cmd in calls
-    )
+    # Payload is printed to stdout by _apply_by_index
 
 
 def test_get_hdmi_modes_not_installed(monkeypatch):
@@ -188,7 +146,7 @@ def test_get_hdmi_modes_installed(monkeypatch):
 
     entries: List[dict] = [
         {"kind": "auto", "value": "auto", "title": "Auto from EDID"},
-        {"kind": "xrandr", "value": "1920x1080", "title": "1920x1080"},
+        {"kind": "mode", "value": "1920x1080", "title": "1920x1080"},
         {
             "kind": "edid",
             "value": "1920x1080-60.00|EDID:148500",
@@ -208,10 +166,33 @@ def test_get_hdmi_modes_installed(monkeypatch):
     values = [e["value"] for e in out]
     # May include auto now
     assert "auto" in values
-    # Includes xrandr and detailed entries
+    # Includes flat modes and detailed entries
     assert "1920x1080" in values
     assert "1920x1080-60.00|EDID:148500" in values
     assert "1920x1080-60.00|CVT:173000" in values
+
+
+def test_get_hdmi_modes_legacy_package_installed(monkeypatch):
+    """wb-hdmi-xorg should also enable HDMI mode discovery for the UI."""
+    hdmi = importlib.import_module("hdmi")
+
+    def fake_check_output(args, text=False):  # pylint: disable=unused-argument
+        package = args[-1]
+        if package == "wb-hdmi":
+            raise hdmi.subprocess.CalledProcessError(returncode=1, cmd=args)
+        if package == "wb-hdmi-xorg":
+            return "install ok installed\n"
+        raise AssertionError("unexpected package query")
+
+    entries: List[dict] = [
+        {"kind": "auto", "value": "auto", "title": "Auto from EDID"},
+    ]
+
+    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(hdmi, "_build_grouped_entries", lambda: entries)  # pylint: disable=protected-access
+
+    out = hdmi.get_hdmi_modes()
+    assert out == [{"value": "auto", "title": "Auto from EDID"}]
 
 
 def test_cvt_modeline_parsing(monkeypatch):
@@ -242,62 +223,8 @@ def test_cvt_modeline_no_cvt(monkeypatch):
     assert payload == ""
 
 
-def test_ensure_mode_present_exists(monkeypatch):
-    """Does nothing when the mode already exists in xrandr output."""
-    hdmi = importlib.import_module("hdmi")
-    mode_name = "1920x1080-60.00"
-
-    def fake_check_output(args, text=False, stderr=None):  # pylint: disable=unused-argument
-        if args and args[0] == "xrandr":
-            return f"...\n{mode_name} 148.50*\n"
-        return ""
-
-    calls = []
-
-    def fake_run(args, check=False, stdout=None, stderr=None):  # pylint: disable=unused-argument
-        calls.append(args)
-
-    monkeypatch.setenv("DISPLAY", ":0.0")
-    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
-    monkeypatch.setattr(hdmi.subprocess, "run", fake_run)
-
-    hdmi._ensure_mode_present(  # pylint: disable=protected-access
-        "HDMI-1",
-        mode_name,
-        '"x" 1 2 3 4 5 6 7 8 +hsync +vsync',
-    )
-    assert not calls  # nothing to add when mode already exists
-
-
-def test_ensure_mode_present_new(monkeypatch):
-    """Creates a new mode and adds it to the output when it does not exist."""
-    hdmi = importlib.import_module("hdmi")
-    mode_name = "1920x1080-60.00"
-    payload = '"1920x1080-60.00" 148.50 1920 2008 2052 2200 1080 1084 1089 1125 +hsync +vsync'
-
-    def fake_check_output(args, text=False, stderr=None):  # pylint: disable=unused-argument
-        if args and args[0] == "xrandr":
-            return ""  # mode not present
-        return ""
-
-    calls = []
-
-    def fake_run(args, check=False, stdout=None, stderr=None):  # pylint: disable=unused-argument
-        calls.append(args)
-
-    monkeypatch.setenv("DISPLAY", ":0.0")
-    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
-    monkeypatch.setattr(hdmi.subprocess, "run", fake_run)
-
-    hdmi._ensure_mode_present("HDMI-1", mode_name, payload)  # pylint: disable=protected-access
-    # Expect two calls: --newmode and --addmode
-    assert len(calls) == 2
-    assert calls[0][:3] == ["xrandr", "--newmode", mode_name]
-    assert calls[1] == ["xrandr", "--addmode", "HDMI-1", mode_name]
-
-
 def test_apply_by_index_auto(monkeypatch, capsys):
-    """Index 0 triggers xrandr --auto and prints the Auto Modeline payload."""
+    """Index 0 prints the Auto Modeline payload."""
     hdmi = importlib.import_module("hdmi")
     entries = [
         {
@@ -306,25 +233,16 @@ def test_apply_by_index_auto(monkeypatch, capsys):
             "payload": '"1920x1080-60.00" 148.50 1920 2008 2052 2200 1080 1084 1089 1125 +hsync +vsync',
         },
     ]
-
-    calls = []
-
-    def fake_run(args, check=False, stdout=None, stderr=None):  # pylint: disable=unused-argument
-        calls.append(args)
-
-    monkeypatch.setenv("DISPLAY", ":0.0")
     monkeypatch.setattr(hdmi, "_build_grouped_entries", lambda: entries)  # pylint: disable=protected-access
-    monkeypatch.setattr(hdmi.subprocess, "run", fake_run)
 
     rc = hdmi._apply_by_index("0")  # pylint: disable=protected-access
     assert rc == 0
     out = capsys.readouterr().out.strip()
     assert out.startswith('"1920x1080-60.00" 148.50')
-    assert any(cmd[:3] == ["xrandr", "--output", "HDMI-1"] and cmd[3] == "--auto" for cmd in calls)
 
 
 def test_build_grouped_entries_aggregates(monkeypatch):
-    """Aggregates Auto, xrandr resolutions, and detailed EDID/CVT entries (>=2.5K width)."""
+    """Aggregates Auto, flat modetest resolutions, and detailed EDID/CVT entries."""
     hdmi = importlib.import_module("hdmi")
 
     # Provide modetest modes: include >=2.5K widths and one below threshold
@@ -379,12 +297,6 @@ def test_build_grouped_entries_aggregates(monkeypatch):
         },
     ]
 
-    # xrandr offers two resolutions
-    monkeypatch.setattr(
-        hdmi,
-        "_parse_xrandr_modes",
-        lambda _o: {"1920x1080": ["60.00"], "3840x2160": ["60.00"]},
-    )  # pylint: disable=protected-access
     monkeypatch.setattr(
         hdmi, "_parse_modetest_modes", lambda: modetest_modes
     )  # pylint: disable=protected-access
@@ -401,10 +313,10 @@ def test_build_grouped_entries_aggregates(monkeypatch):
     assert entries[0]["kind"] == "auto"
     assert entries[0]["name"] == "3840x2160-60.00"
 
-    # Next, xrandr entries should include 3840x2160 and 1920x1080
-    xr = [e for e in entries if e.get("kind") == "xrandr"]
-    xr_values = {e["value"] for e in xr}
-    assert {"3840x2160", "1920x1080"}.issubset(xr_values)
+    # Next, flat mode entries should include all unique modetest resolutions
+    basic = [e for e in entries if e.get("kind") == "mode"]
+    basic_values = {e["value"] for e in basic}
+    assert {"3840x2160", "2560x1440", "1920x1080"}.issubset(basic_values)
 
     # Detailed entries include EDID and CVT for >=2560 widths
     det = [e for e in entries if e.get("kind") in {"edid", "cvt"}]
@@ -419,27 +331,10 @@ def test_build_grouped_entries_aggregates(monkeypatch):
     assert "edid" in kinds_per_name["2560x1440-59.95"] and "cvt" in kinds_per_name["2560x1440-59.95"]
 
 
-def test_parse_xrandr_modes_no_tools(monkeypatch):
-    """Returns an empty mapping when both xrandr and modetest are unavailable."""
-    hdmi = importlib.import_module("hdmi")
-
-    def fake_check_output(args, text=False, stderr=None):  # pylint: disable=unused-argument
-        if args[:2] == ["xrandr", "--query"]:
-            raise FileNotFoundError
-        return ""
-
-    monkeypatch.setattr(hdmi.subprocess, "check_output", fake_check_output)
-    monkeypatch.setattr(hdmi, "_run_modetest", lambda: "")  # pylint: disable=protected-access
-
-    out = hdmi._parse_xrandr_modes("HDMI-1")  # pylint: disable=protected-access
-    assert out == {}
-
-
 def test_build_grouped_entries_no_tools(monkeypatch):
-    """With no xrandr or modetest, returns only the Auto entry with empty payload."""
+    """With no modetest, returns only the Auto entry with empty payload."""
     hdmi = importlib.import_module("hdmi")
     monkeypatch.setattr(hdmi, "_parse_modetest_modes", lambda: [])  # pylint: disable=protected-access
-    monkeypatch.setattr(hdmi, "_parse_xrandr_modes", lambda _o: {})  # pylint: disable=protected-access
 
     entries = hdmi._build_grouped_entries()  # pylint: disable=protected-access
     assert len(entries) == 1
@@ -453,6 +348,60 @@ def test_build_grouped_entries_no_tools(monkeypatch):
 def test_clean_monitor_field():
     hdmi = importlib.import_module("hdmi")
     assert hdmi._clean_monitor_field("  'Panel 123'  ") == "Panel 123"  # pylint: disable=protected-access
+
+
+def test_find_connected_hdmi_edid(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+
+    monkeypatch.setattr(
+        hdmi.glob,
+        "glob",
+        lambda pattern: [
+            "/sys/class/drm/card0-HDMI-A-1/status",
+            "/sys/class/drm/card1-HDMI-A-1/status",
+        ],
+    )
+
+    def fake_open(path, mode="r", encoding=None):  # pylint: disable=unused-argument
+        class FakeFile:
+            def __init__(self, value):
+                self.value = value
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return self.value
+
+        if path.endswith("card0-HDMI-A-1/status"):
+            return FakeFile("disconnected\n")
+        if path.endswith("card1-HDMI-A-1/status"):
+            return FakeFile("connected\n")
+        raise AssertionError(f"unexpected open path: {path}")
+
+    monkeypatch.setattr(hdmi, "open", fake_open, raising=False)
+    monkeypatch.setattr(hdmi.os.path, "exists", lambda path: path.endswith("card1-HDMI-A-1/edid"))
+
+    find_connected_hdmi_edid = getattr(hdmi, "_find_connected_hdmi_edid")
+
+    assert find_connected_hdmi_edid() == "/sys/class/drm/card1-HDMI-A-1/edid"
+
+
+def test_read_monitor_name_uses_connected_hdmi(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+
+    monkeypatch.setattr(
+        hdmi,
+        "_find_connected_hdmi_edid",
+        lambda: "/sys/class/drm/card1-HDMI-A-1/edid",
+    )  # pylint: disable=protected-access
+    monkeypatch.setattr(hdmi.os.path, "exists", lambda path: True)
+    monkeypatch.setattr(hdmi.subprocess, "check_output", lambda *a, **k: "Display Product Name: 'Panel'")
+
+    assert hdmi._read_monitor_name() == "Panel"  # pylint: disable=protected-access
 
 
 def test_read_monitor_name_prefers_display_product_name(monkeypatch):
@@ -499,9 +448,10 @@ def test_get_monitor_info(monkeypatch):
     monkeypatch.setattr(
         hdmi, "_read_monitor_name", lambda _p=None: "Demo Panel"
     )  # pylint: disable=protected-access
+    monkeypatch.setattr(hdmi, "_read_current_resolution", lambda: "1920x1080")  # pylint: disable=protected-access
 
     info = hdmi.get_monitor_info()
-    assert info == "Demo Panel (max: 3840x2160)"
+    assert info == "Demo Panel (max: 3840x2160, current: 1920x1080)"
 
 
 def test_get_monitor_info_no_monitor(monkeypatch):
@@ -511,6 +461,13 @@ def test_get_monitor_info_no_monitor(monkeypatch):
 
     info = hdmi.get_monitor_info()
     assert info == "No monitor detected"
+
+
+def test_read_current_resolution(monkeypatch):
+    hdmi = importlib.import_module("hdmi")
+    monkeypatch.setattr(hdmi, "_run_modetest_full", lambda: MODETEST_WITH_CRTC_SAMPLE)  # pylint: disable=protected-access
+
+    assert hdmi._read_current_resolution() == "1280x720"  # pylint: disable=protected-access
 
 
 def test_read_monitor_name_missing_file(monkeypatch):

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 from typing import List
 
-
 MODETEST_SAMPLE = """
 Connectors:
 id	encoder	status		name		size (mm)	modes	encoders

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -134,6 +134,7 @@ def test_get_hdmi_modes_not_installed(monkeypatch):
     assert isinstance(out, list) and len(out) == 1
     assert out[0]["value"] == "auto"
     assert "wb-hdmi" in out[0]["title"]
+    assert "wb-hdmi-xorg" in out[0]["title"]
 
 
 def test_get_hdmi_modes_installed(monkeypatch):

--- a/test/hdmi/test_hdmi.py
+++ b/test/hdmi/test_hdmi.py
@@ -32,6 +32,7 @@ id	fb	pos	size
 51	55	(0,0)	(1280x720)
 """.strip()
 
+
 def test_build_basic_entries_from_modetest(monkeypatch):
     """Builds flat unique resolutions from modetest data."""
     hdmi = importlib.import_module("hdmi")
@@ -449,7 +450,9 @@ def test_get_monitor_info(monkeypatch):
     monkeypatch.setattr(
         hdmi, "_read_monitor_name", lambda _p=None: "Demo Panel"
     )  # pylint: disable=protected-access
-    monkeypatch.setattr(hdmi, "_read_current_resolution", lambda: "1920x1080")  # pylint: disable=protected-access
+    monkeypatch.setattr(
+        hdmi, "_read_current_resolution", lambda: "1920x1080"
+    )  # pylint: disable=protected-access
 
     info = hdmi.get_monitor_info()
     assert info == "Demo Panel (max: 3840x2160, current: 1920x1080)"
@@ -466,7 +469,9 @@ def test_get_monitor_info_no_monitor(monkeypatch):
 
 def test_read_current_resolution(monkeypatch):
     hdmi = importlib.import_module("hdmi")
-    monkeypatch.setattr(hdmi, "_run_modetest_full", lambda: MODETEST_WITH_CRTC_SAMPLE)  # pylint: disable=protected-access
+    monkeypatch.setattr(
+        hdmi, "_run_modetest_full", lambda: MODETEST_WITH_CRTC_SAMPLE
+    )  # pylint: disable=protected-access
 
     assert hdmi._read_current_resolution() == "1280x720"  # pylint: disable=protected-access
 

--- a/wb-hardware.schema.json
+++ b/wb-hardware.schema.json
@@ -325,7 +325,7 @@
             "Browser launch mode": "Режим запуска браузера",
             "Kiosk mode": "Режим киоска",
             "Window mode": "Оконный режим",
-            "To use the graphical interface, you need to install the wb-hdmi or wb-hdmi-wayland package: apt install wb-hdmi": "Для работы с графическим интерфейсом необходимо установить пакет wb-hdmi или wb-hdmi-wayland: apt install wb-hdmi"
+            "To use the graphical interface, you need to install the wb-hdmi or wb-sway-kiosk package: apt install wb-hdmi": "Для работы с графическим интерфейсом необходимо установить пакет wb-hdmi или wb-sway-kiosk: apt install wb-hdmi"
 
         }
     }

--- a/wb-hardware.schema.json
+++ b/wb-hardware.schema.json
@@ -325,7 +325,7 @@
             "Browser launch mode": "Режим запуска браузера",
             "Kiosk mode": "Режим киоска",
             "Window mode": "Оконный режим",
-            "To use the graphical interface, you need to install the wb-hdmi or wb-hdmi-xorg package: apt install wb-hdmi": "Для работы с графическим интерфейсом необходимо установить пакет wb-hdmi или wb-hdmi-xorg: apt install wb-hdmi"
+            "To use the graphical interface, you need to install the wb-hdmi or wb-hdmi-wayland package: apt install wb-hdmi": "Для работы с графическим интерфейсом необходимо установить пакет wb-hdmi или wb-hdmi-wayland: apt install wb-hdmi"
 
         }
     }

--- a/wb-hardware.schema.json
+++ b/wb-hardware.schema.json
@@ -325,7 +325,7 @@
             "Browser launch mode": "Режим запуска браузера",
             "Kiosk mode": "Режим киоска",
             "Window mode": "Оконный режим",
-            "To use the graphical interface, you need to install the wb-hdmi package: apt install wb-hdmi": "Для работы с графическим интерфейсом необходимо установить пакет wb-hdmi: apt install wb-hdmi"
+            "To use the graphical interface, you need to install the wb-hdmi or wb-hdmi-xorg package: apt install wb-hdmi": "Для работы с графическим интерфейсом необходимо установить пакет wb-hdmi или wb-hdmi-xorg: apt install wb-hdmi"
 
         }
     }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил поддержку новой HDMI-схемы с двумя графическими стеками: старым Xorg и новым Wayland/Sway. Это нужно для перехода на wb-sway, но без поломки уже существующих установок, где HDMI работает через wb-hdmi.

___________________________________
**Что поменялось для пользователей:**
hwconf и UI теперь понимают два варианта графического стека: wb-hdmi для Xorg и wb-hdmi-wayland для Wayland. Обновлена подсказка по установке пакетов, а список режимов экрана теперь строится только по modetest и EDID, без генерации CVT modeline.

___________________________________
**Как проверял/а:**
Проверял логику на контроллерах 8.5.1 и 8.5.3: накатывал собранные deb-ки, смотрел работу wb-hwconf-manager, подсказки в UI и отображение режимов мониторов (наша панелька с тачем, 4К-монитор).