### PR TITLE
Fix title of rs485-1/rs485-2/w1/w2 slots

### DIFF
--- a/boards/wb61.conf
+++ b/boards/wb61.conf
@@ -94,6 +94,7 @@
             "compatible": ["wb6-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb6-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled"
             }
@@ -104,6 +105,7 @@
             "compatible": ["wb6-rs485", "wb6-can"],
             "name": "RS485-2/CAN interface config",
             "module": "wb6-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled"
             }
@@ -114,6 +116,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -122,6 +125,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {

--- a/boards/wb67.conf
+++ b/boards/wb67.conf
@@ -102,6 +102,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -113,6 +114,7 @@
             "compatible": ["wb67-rs485", "wb67-can"],
             "name": "RS485-2/CAN interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -132,6 +134,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -140,6 +143,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {

--- a/boards/wb72x-73x.conf
+++ b/boards/wb72x-73x.conf
@@ -102,6 +102,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -113,6 +114,7 @@
             "compatible": ["wb67-rs485", "wb67-can"],
             "name": "RS485-2/CAN interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -132,6 +134,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -140,6 +143,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {

--- a/boards/wb730.conf
+++ b/boards/wb730.conf
@@ -102,6 +102,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -113,6 +114,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-2 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -132,6 +134,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -140,6 +143,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {

--- a/boards/wb74x.conf
+++ b/boards/wb74x.conf
@@ -102,6 +102,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -113,6 +114,7 @@
             "compatible": ["wb67-rs485", "wb67-can"],
             "name": "RS485-2 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -132,6 +134,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -140,6 +143,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {

--- a/boards/wb84x.conf
+++ b/boards/wb84x.conf
@@ -94,6 +94,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -105,6 +106,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-2 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -124,6 +126,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -132,6 +135,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {

--- a/boards/wb85x.conf
+++ b/boards/wb85x.conf
@@ -102,6 +102,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -113,6 +114,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-2 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -132,6 +134,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -140,6 +143,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         }
     ]

--- a/boards/wb85xm.conf
+++ b/boards/wb85xm.conf
@@ -38,6 +38,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-1 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -49,6 +50,7 @@
             "compatible": ["wb67-rs485"],
             "name": "RS485-2 interface config",
             "module": "wb67-can-rs485",
+            "interface": true,
             "options": {
                 "mode": "enabled",
                 "terminatorsMode": "enabled"
@@ -68,6 +70,7 @@
             "compatible": ["wb6-wx"],
             "name": "W1 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         },
         {
@@ -76,6 +79,7 @@
             "compatible": ["wb6-wx"],
             "name": "W2 terminal mode",
             "module": "wb6-wx-1wire",
+            "interface": true,
             "options": {}
         }
     ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.71.2) stable; urgency=medium
+
+  * Fix title of rs485-1/rs485-2/w1/w2 slots
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Mar 2026 14:05:00 +0400
+
 wb-hwconf-manager (1.71.1) stable; urgency=medium
 
   * wb85x: fix wrong gpio numbers resolving in mod1 & mod2 slots

--- a/debian/control
+++ b/debian/control
@@ -1,13 +1,13 @@
 Source: wb-hwconf-manager
 Section: misc
-Priority: extra
+Priority: optional
 Maintainer: Wiren Board team <info@wirenboard.com>
 Build-Depends: debhelper (>= 8.0.0),
                jq,
                python3-all,
                python3-pytest,
                python3-tomli
-Standards-Version: 3.9.4
+Standards-Version: 4.5.1
 Homepage: https://github.com/wirenboard/wb-hwconf-manager
 
 Package: wb-hwconf-manager

--- a/wb-hardware.schema.json
+++ b/wb-hardware.schema.json
@@ -13,7 +13,7 @@
                 "collapsed": true
             }
         },
-        "slot": {
+        "slot_base": {
             "type": "object",
             "headerTemplate": "{{translate self.name}}",
             "id": "slot_item",
@@ -47,36 +47,12 @@
                         "hidden": true
                     }
                 },
-                "module": {
-                    "title": "Module type",
-                    "description": "Type of the module plugged to the slot",
-                    "type": "string",
-                    "watch": {
-                        "all_modules": "modules",
-                        "slot_compatible": "slot_item.compatible"
-                    },
+                "interface": {
+                    "type": "boolean",
+                    "default": false,
                     "options": {
-                        "enum_hidden": []
-                    },
-                    "enumSource": [
-                        {
-                            "source": [
-                                {
-                                    "title": "None",
-                                    "value": ""
-                                }
-                            ],
-                            "title": "{{item.title}}",
-                            "value": "{{item.value}}"
-                        },
-                        {
-                            "source": "all_modules",
-                            "filter": "{{if watched.slot_compatible intersect item.compatible_slots}}1{{endif}}",
-                            "title": "{{item.description}}",
-                            "value": "{{item.id}}"
-                        }
-                    ],
-                    "propertyOrder": 2
+                        "hidden": true
+                    }
                 },
                 "options": {
                     "type": "object",
@@ -107,8 +83,105 @@
                 "id",
                 "name",
                 "compatible",
+                "interface",
                 "module",
                 "options"
+            ]
+        },
+        "slot": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/slot_base"
+                },
+                {
+                    "properties": {
+                        "interface": {
+                            "type": "boolean",
+                            "default": false,
+                            "enum": [
+                                false
+                            ],
+                            "options": {
+                                "hidden": true
+                            }
+                        },
+                        "module": {
+                            "title": "Module type",
+                            "description": "Type of the module plugged to the slot",
+                            "type": "string",
+                            "watch": {
+                                "all_modules": "modules",
+                                "slot_compatible": "slot_item.compatible"
+                            },
+                            "options": {
+                                "enum_hidden": []
+                            },
+                            "enumSource": [
+                                {
+                                    "source": [
+                                        {
+                                            "title": "None",
+                                            "value": ""
+                                        }
+                                    ],
+                                    "title": "{{item.title}}",
+                                    "value": "{{item.value}}"
+                                },
+                                {
+                                    "source": "all_modules",
+                                    "filter": "{{if watched.slot_compatible intersect item.compatible_slots}}1{{endif}}",
+                                    "title": "{{item.description}}",
+                                    "value": "{{item.id}}"
+                                }
+                            ],
+                            "propertyOrder": 2
+                        }
+                    }
+                }
+            ]
+        },
+        "interface": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/slot_base"
+                },
+                {
+                    "properties": {
+                        "interface": {
+                            "type": "boolean",
+                            "default": true,
+                            "enum": [
+                                true
+                            ],
+                            "options": {
+                                "hidden": true
+                            }
+                        },
+                        "module": {
+                            "title": "Interface",
+                            "type": "string",
+                            "watch": {
+                                "all_modules": "modules",
+                                "slot_compatible": "slot_item.compatible"
+                            },
+                            "options": {
+                                "enum_hidden": []
+                            },
+                            "enumSource": [
+                                {
+                                    "source": "all_modules",
+                                    "filter": "{{if watched.slot_compatible intersect item.compatible_slots}}1{{endif}}",
+                                    "title": "{{item.description}}",
+                                    "value": "{{item.id}}"
+                                }
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "required": [
+                        "interface"
+                    ]
+                }
             ]
         },
         "module": {
@@ -164,7 +237,16 @@
                 }
             },
             "items": {
-                "$ref": "#/definitions/slot"
+                "headerTemplate": "{{translate self.name}}",
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/slot"
+                    },
+                    {
+                        "$ref": "#/definitions/interface"
+                    }
+                ],
+                "format": "wb-first-oneof"
             },
             "_format": "tabs",
             "propertyOrder": 1
@@ -190,11 +272,12 @@
     "options": {
         "disable_collapse": true
     },
-        "translations": {
-            "ru": {
-                "Hardware Modules Configuration": "Модули расширения и порты",
-                "List of extension slots": "Список слотов расширения",
-                "Module type": "Тип модуля",
+    "translations": {
+        "ru": {
+            "Hardware Modules Configuration": "Модули расширения и порты",
+            "List of extension slots": "Список слотов расширения",
+            "Module type": "Тип модуля",
+            "Interface": "Интерфейс",
             "Type of the module plugged to the slot": "Тип модуля, установленного в слоте",
             "None": "Не установлен",
             "Internal slot 1": "Внутренний слот 1",
@@ -326,7 +409,6 @@
             "Kiosk mode": "Режим киоска",
             "Window mode": "Оконный режим",
             "To use the graphical interface, you need to install the wb-hdmi package: apt install wb-hdmi": "Для работы с графическим интерфейсом необходимо установить пакет wb-hdmi: apt install wb-hdmi"
-
         }
     }
 }

--- a/wb-hardware.schema.json
+++ b/wb-hardware.schema.json
@@ -69,14 +69,12 @@
             "required": [
                 "id",
                 "name",
-                "compatible",
-                "module"
+                "compatible"
             ],
             "defaultProperties": [
                 "id",
                 "name",
                 "compatible",
-                "module",
                 "options"
             ]
         },
@@ -128,7 +126,17 @@
                             ],
                             "propertyOrder": 2
                         }
-                    }
+                    },
+                    "required": [
+                        "module"
+                    ],
+                    "defaultProperties": [
+                        "id",
+                        "name",
+                        "compatible",
+                        "module",
+                        "options"
+                    ]
                 }
             ]
         },
@@ -171,7 +179,15 @@
                         }
                     },
                     "required": [
-                        "interface"
+                        "interface",
+                        "module"
+                    ],
+                    "defaultProperties": [
+                        "id",
+                        "name",
+                        "compatible",
+                        "module",
+                        "options"
                     ]
                 }
             ]

--- a/wb-hardware.schema.json
+++ b/wb-hardware.schema.json
@@ -47,13 +47,6 @@
                         "hidden": true
                     }
                 },
-                "interface": {
-                    "type": "boolean",
-                    "default": false,
-                    "options": {
-                        "hidden": true
-                    }
-                },
                 "options": {
                     "type": "object",
                     "title": " ",
@@ -83,7 +76,6 @@
                 "id",
                 "name",
                 "compatible",
-                "interface",
                 "module",
                 "options"
             ]


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Добавлен флаг `interface=true` для rs485-1/rs485-2/w1/w2 чтобы для обратной совместимости конфига не трогать `module` параметр. Title/description выбирается в зависимости от этого флага. Для таких интерфейсов из енума убран "None", так как это не имеет смысла, при выборе "None" интерфейс не отключается, как можно было бы предположить.


До:

<img width="507" height="320" alt="Screen Shot 2026-03-26 at 15 37 57" src="https://github.com/user-attachments/assets/6d85696b-4161-447c-a713-bf6ecd055afa" />
<img width="533" height="367" alt="Screen Shot 2026-03-26 at 15 38 03" src="https://github.com/user-attachments/assets/92d8908c-3b58-40c0-a432-ac377ab9fe62" />

После:

<img width="368" height="269" alt="Screen Shot 2026-03-26 at 15 37 10" src="https://github.com/user-attachments/assets/bcb9dffe-f825-4d28-b404-441c06b0d881" />
<img width="480" height="290" alt="Screen Shot 2026-03-26 at 15 37 17" src="https://github.com/user-attachments/assets/5d47ae15-040a-43ef-acdf-7289546f6d3e" />

___________________________________
**Что поменялось для пользователей:**
корректные подписи к полям в UI

___________________________________
**Как проверял/а:**
на вб

