### PR TITLE
Feature/can wb7

### DIFF
--- a/boards/wb72x-73x.conf
+++ b/boards/wb72x-73x.conf
@@ -3,7 +3,7 @@
         {
             "slot_id": "mod1",
             "id": "wb72-mod1",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 1",
             "module": "",
             "options": {}
@@ -11,7 +11,7 @@
         {
             "slot_id": "mod2",
             "id": "wb72-mod2",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 2",
             "module": "",
             "options": {}
@@ -19,7 +19,7 @@
         {
             "slot_id": "mod3",
             "id": "wb72-mod3",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 3",
             "module": "",
             "options": {}

--- a/boards/wb730.conf
+++ b/boards/wb730.conf
@@ -3,7 +3,7 @@
         {
             "slot_id": "mod1",
             "id": "wb72-mod1",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 1",
             "module": "",
             "options": {}
@@ -11,7 +11,7 @@
         {
             "slot_id": "mod2",
             "id": "wb72-mod2",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 2",
             "module": "",
             "options": {}
@@ -19,7 +19,7 @@
         {
             "slot_id": "mod3",
             "id": "wb72-mod3",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 3",
             "module": "",
             "options": {}

--- a/boards/wb74x.conf
+++ b/boards/wb74x.conf
@@ -3,7 +3,7 @@
         {
             "slot_id": "mod1",
             "id": "wb72-mod1",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 1",
             "module": "",
             "options": {}
@@ -11,7 +11,7 @@
         {
             "slot_id": "mod2",
             "id": "wb72-mod2",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 2",
             "module": "",
             "options": {}
@@ -19,7 +19,7 @@
         {
             "slot_id": "mod3",
             "id": "wb74-mod3",
-            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart"],
+            "compatible": ["wbe2", "wbe2-gpio", "wbe2-i2c", "wbe3-reduced", "wbe3-reduced-uart", "wbe2-i-can"],
             "name": "Internal slot 3",
             "module": "",
             "options": {}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.71.4) stable; urgency=medium
+
+  * wb7: add WBE2 CAN module to internal slots
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 27 Apr 2026 11:00:33 +0300
+
 wb-hwconf-manager (1.71.3) stable; urgency=medium
 
   * HDMI:


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил поддержку CAN-модулей в wb7

___________________________________
**Что поменялось для пользователей:**
Могут тыкать модули в wb7

___________________________________
**Как проверял/а:**
На 7.2.1/7.3.4/7.4.3 - установив и сконфигурировав 3 модуля (MOD1-3), гоняя трафик между модулями и внутренним can-ом в разных конфигурациях через candump
Также проверил вкл/откл резистора-терминатора.2

