### PR TITLE
Add util-linux-extra to dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-hwconf-manager (1.72.2) stable; urgency=medium
+
+  * Add util-linux-extra to dependencies
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 27 Jul 2026 17:05:00 +0400
+
 wb-hwconf-manager (1.72.1) stable; urgency=medium
 
   * Fix dependencies

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends: ${shlibs:Depends},
          mqtt-tools (>= 1.1.1),
          wb-rules-system (>= 1.6.8),
          ntpstat,
+         util-linux-extra,
          python3 (>= 3.5)
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-homa-adc (<< 2.5.0), wb-mqtt-homeui (<< 1.6.1), wb-knxd-config (<< 1.0.4~~), wb-mqtt-dac (<< 1.2.0)
 Description: Provides infrastructure for hardware re-configuration via Device Tree overlays


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
https://github.com/wirenboard/wb-hwconf-manager/blob/6e080729691efe4b352d2d4d3424f193ddaefb02/modules/wbe2r-rtc.sh#L7-L14 тут используется hwclock, но его теперь по дефолту нет в трикси, нужен util-linux-extra

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


